### PR TITLE
fix: resolve all CI lint and test failures

### DIFF
--- a/src/herald/agent/agent.py
+++ b/src/herald/agent/agent.py
@@ -28,10 +28,9 @@ import sys
 
 import anthropic
 
+from herald.agent.tools import TOOL_DEFINITIONS, execute_tool
 from herald.core.config import load_config
 from herald.pipeline.escalation import build_pipeline
-from herald.agent.tools import TOOL_DEFINITIONS, execute_tool
-
 
 SYSTEM_PROMPT = """You are HERALD, an interactive LLM evaluation assistant specializing in \
 validating economics research agent outputs for faithfulness to their source material.
@@ -85,10 +84,7 @@ def _print_streaming(stream: anthropic.Stream) -> str:
     """Stream response text to stdout and return the full text."""
     full_text = ""
     for event in stream:
-        if (
-            event.type == "content_block_delta"
-            and event.delta.type == "text_delta"
-        ):
+        if event.type == "content_block_delta" and event.delta.type == "text_delta":
             chunk = event.delta.text
             print(chunk, end="", flush=True)
             full_text += chunk
@@ -202,11 +198,13 @@ def run_agent(config_path: str = "configs/default.yaml", verbose: bool = False) 
                 if verbose:
                     print(f"[Tool result: {result_str[:300]}...]")
 
-                tool_results.append({
-                    "type": "tool_result",
-                    "tool_use_id": block.id,
-                    "content": result_str,
-                })
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": result_str,
+                    }
+                )
 
             messages.append({"role": "user", "content": tool_results})
             # Loop continues — Claude will now respond to tool results
@@ -232,7 +230,8 @@ Examples:
         help="Path to HERALD config YAML (default: configs/default.yaml)",
     )
     parser.add_argument(
-        "--verbose", "-v",
+        "--verbose",
+        "-v",
         action="store_true",
         help="Show tool call inputs/outputs for debugging",
     )
@@ -248,6 +247,7 @@ Examples:
 
     if args.research:
         from herald.agent.research_agent import run_research_agent
+
         run_research_agent(config_path=args.config, verbose=args.verbose)
     else:
         run_agent(config_path=args.config, verbose=args.verbose)

--- a/src/herald/agent/analyzer.py
+++ b/src/herald/agent/analyzer.py
@@ -133,9 +133,7 @@ class TaskAnalyzer:
                 if attempt < max_retries - 1:
                     time.sleep(retry_delay)
 
-        raise RuntimeError(
-            f"TaskAnalyzer failed after {max_retries} attempts: {last_err}"
-        )
+        raise RuntimeError(f"TaskAnalyzer failed after {max_retries} attempts: {last_err}")
 
     def _parse_plan(self, data: dict) -> TaskPlan:
         """Parse and validate raw JSON into a TaskPlan."""

--- a/src/herald/agent/batch.py
+++ b/src/herald/agent/batch.py
@@ -18,8 +18,7 @@ import logging
 import math
 import random
 import time
-import uuid
-from typing import Callable
+from collections.abc import Callable
 
 from herald.core.types import (
     BatchValidationResult,
@@ -78,10 +77,7 @@ class BatchValidator:
 
         total = len(to_validate)
         for idx, output in enumerate(to_validate, 1):
-            self._progress(
-                f"  Validating {output.output_type} {idx}/{total} "
-                f"[id: {output.id}]..."
-            )
+            self._progress(f"  Validating {output.output_type} {idx}/{total} [id: {output.id}]...")
 
             checkpoint_type = self.map_to_checkpoint_type(output, task_plan)
             source_context = self.extract_source_context(output, sources, task_plan.source_chunking)
@@ -108,7 +104,7 @@ class BatchValidator:
                     self._progress(f"    → Tier 1: INVALID ({t1.confidence:.2f})")
             elif packet.resolved_at_tier == 4:
                 tier4_pending.append((output, packet))
-                self._progress(f"    → Tier 4: UNCERTAIN (needs human review)")
+                self._progress("    → Tier 4: UNCERTAIN (needs human review)")
             else:
                 escalated.append((output, packet))
                 verdict_str = packet.final_verdict.value.upper() if packet.final_verdict else "?"
@@ -204,9 +200,7 @@ class BatchValidator:
         if len(outputs) <= 20:
             return outputs
         n = min(20, math.ceil(0.15 * len(outputs)))
-        self._progress(
-            f"  Adaptive sampling: validating {n}/{len(outputs)} outputs"
-        )
+        self._progress(f"  Adaptive sampling: validating {n}/{len(outputs)} outputs")
         return random.sample(outputs, n)
 
     def _run_with_backoff(
@@ -226,7 +220,7 @@ class BatchValidator:
                 err_str = str(exc).lower()
                 is_rate_limit = "429" in err_str or "rate limit" in err_str or "too many" in err_str
                 if is_rate_limit and attempt < max_retries - 1:
-                    wait = delay * (2 ** attempt)
+                    wait = delay * (2**attempt)
                     logger.warning(
                         f"[BatchValidator] Rate limit hit, retrying in {wait:.1f}s "
                         f"(attempt {attempt + 1}/{max_retries})"
@@ -256,9 +250,7 @@ class BatchValidator:
         )
 
         # Run Tier 2 directly via the pipeline's judge
-        t2 = self.pipeline.tier2.judge(
-            checkpoint, fake_t1, threshold=self.pipeline.t2
-        )
+        t2 = self.pipeline.tier2.judge(checkpoint, fake_t1, threshold=self.pipeline.t2)
 
         packet = EscalationPacket(checkpoint=checkpoint)
         packet.tier1_result = fake_t1

--- a/src/herald/agent/research_agent.py
+++ b/src/herald/agent/research_agent.py
@@ -24,6 +24,9 @@ import uuid
 
 import anthropic
 
+from herald.agent.analyzer import TaskAnalyzer
+from herald.agent.batch import BatchValidator
+from herald.agent.tools import store_packet
 from herald.core.config import load_config
 from herald.core.types import (
     BatchValidationResult,
@@ -33,9 +36,6 @@ from herald.core.types import (
     Verdict,
 )
 from herald.pipeline.escalation import build_pipeline
-from herald.agent.analyzer import TaskAnalyzer
-from herald.agent.batch import BatchValidator
-from herald.agent.tools import store_packet, TOOL_DEFINITIONS, execute_tool
 
 logger = logging.getLogger("herald")
 
@@ -99,15 +99,11 @@ class ResearchAgent:
 
         anthropic_key = config.get("anthropic_api_key", "")
         if not anthropic_key:
-            raise ValueError(
-                "ANTHROPIC_API_KEY not set. Add it to your .env file."
-            )
+            raise ValueError("ANTHROPIC_API_KEY not set. Add it to your .env file.")
 
         self.client = anthropic.Anthropic(api_key=anthropic_key)
 
-        analysis_model = config.get("task_analysis", {}).get(
-            "model", "claude-sonnet-4-20250514"
-        )
+        analysis_model = config.get("task_analysis", {}).get("model", "claude-sonnet-4-20250514")
         self.analyzer = TaskAnalyzer(client=self.client, model=analysis_model)
 
         print("Loading HERALD pipeline (Tier 1 NLI model may take a moment)...")
@@ -137,7 +133,7 @@ class ResearchAgent:
         # ── Phase 0: Task Analysis ───────────────────────────────────────────
         print("\n[Phase 0] Analyzing task structure...")
         task_plan = self.analyzer.analyze(query, source_documents)
-        print(f"  Task analysis complete.")
+        print("  Task analysis complete.")
         print(f"  Expected outputs: {task_plan.expected_output_count} {task_plan.output_unit}(s)")
         print(f"  Checkpoint types: {[ct.value for ct in task_plan.primary_checkpoint_types]}")
         print(f"  Evaluation mode: {task_plan.evaluation_mode}")
@@ -169,7 +165,7 @@ class ResearchAgent:
         print(f"  Generated {len(outputs)} {task_plan.output_unit}(s).")
 
         # ── Phase 2: Batch Validation ────────────────────────────────────────
-        print(f"\n[Phase 2] Validating outputs...")
+        print("\n[Phase 2] Validating outputs...")
         result = self.batch_validator.validate_batch(outputs, source_documents, task_plan)
 
         s = result.summary
@@ -182,7 +178,7 @@ class ResearchAgent:
 
         # ── Phase 3: Handle Escalations ──────────────────────────────────────
         if result.tier1_invalid or result.tier4_pending:
-            print(f"\n[Phase 3] Handling escalations...")
+            print("\n[Phase 3] Handling escalations...")
 
         # Attempt revision of INVALID outputs
         if result.tier1_invalid:
@@ -192,9 +188,7 @@ class ResearchAgent:
 
         # Surface Tier 4 cases to human
         if result.tier4_pending:
-            print(
-                f"\n  {len(result.tier4_pending)} output(s) require human review (Tier 4)."
-            )
+            print(f"\n  {len(result.tier4_pending)} output(s) require human review (Tier 4).")
             for output, packet in result.tier4_pending:
                 # Store packet so user can call explain_verdict
                 pid = store_packet(packet)
@@ -206,9 +200,9 @@ class ResearchAgent:
                     print(f"  Debate judge: {packet.tier3_result.judge_reasoning[:300]}")
                 print()
                 try:
-                    verdict_input = input(
-                        "  Your verdict [valid/invalid/uncertain/skip]: "
-                    ).strip().lower()
+                    verdict_input = (
+                        input("  Your verdict [valid/invalid/uncertain/skip]: ").strip().lower()
+                    )
                 except (EOFError, KeyboardInterrupt):
                     verdict_input = "skip"
 
@@ -284,17 +278,19 @@ class ResearchAgent:
                 except ValueError:
                     pass
 
-            outputs.append(GeneratedOutput(
-                id=output_id,
-                text=item.get("text", ""),
-                output_type=item.get("output_type", task_plan.output_unit),
-                references_section=item.get("references_section"),
-                suggested_checkpoint_type=suggested_ct,
-                metadata={
-                    "query": query,
-                    **item.get("metadata", {}),
-                },
-            ))
+            outputs.append(
+                GeneratedOutput(
+                    id=output_id,
+                    text=item.get("text", ""),
+                    output_type=item.get("output_type", task_plan.output_unit),
+                    references_section=item.get("references_section"),
+                    suggested_checkpoint_type=suggested_ct,
+                    metadata={
+                        "query": query,
+                        **item.get("metadata", {}),
+                    },
+                )
+            )
 
         return outputs, None
 
@@ -353,6 +349,7 @@ class ResearchAgent:
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
+
 def _task_plan_to_dict(plan: TaskPlan) -> dict:
     return {
         "expected_output_count": plan.expected_output_count,
@@ -370,6 +367,7 @@ def _task_plan_to_dict(plan: TaskPlan) -> dict:
 
 
 # ── Interactive session ──────────────────────────────────────────────────────
+
 
 def run_research_agent(
     config_path: str = "configs/default.yaml",
@@ -422,11 +420,12 @@ def run_research_agent(
             continue
 
         try:
-            result = agent.run(query=query, source_documents=sources)
+            agent.run(query=query, source_documents=sources)
         except Exception as exc:
             print(f"\nError: {exc}", file=sys.stderr)
             if verbose:
                 import traceback
+
                 traceback.print_exc()
 
         print("\n" + "-" * 60 + "\n")
@@ -449,7 +448,8 @@ Examples:
         help="Path to HERALD config YAML (default: configs/default.yaml)",
     )
     parser.add_argument(
-        "--verbose", "-v",
+        "--verbose",
+        "-v",
         action="store_true",
         help="Show full TaskPlan and debug output",
     )

--- a/src/herald/agent/tools.py
+++ b/src/herald/agent/tools.py
@@ -12,7 +12,6 @@ Six tools:
 
 import json
 import uuid
-from typing import Optional
 
 import anthropic
 
@@ -23,7 +22,6 @@ from herald.core.types import (
     Verdict,
 )
 from herald.pipeline.escalation import HeraldPipeline
-
 
 # ── In-memory store so the agent can reference prior results by ID ──────────
 _packet_store: dict[str, EscalationPacket] = {}
@@ -36,7 +34,7 @@ def store_packet(packet: EscalationPacket) -> str:
     return pid
 
 
-def get_packet(pid: str) -> Optional[EscalationPacket]:
+def get_packet(pid: str) -> EscalationPacket | None:
     return _packet_store.get(pid)
 
 
@@ -197,8 +195,12 @@ TOOL_DEFINITIONS = [
                             "suggested_checkpoint_type": {
                                 "type": "string",
                                 "enum": [
-                                    "retrieval", "claim_extraction", "synthesis",
-                                    "numerical", "causal", "epistemic",
+                                    "retrieval",
+                                    "claim_extraction",
+                                    "synthesis",
+                                    "numerical",
+                                    "causal",
+                                    "epistemic",
                                 ],
                             },
                         },
@@ -249,6 +251,7 @@ TOOL_DEFINITIONS = [
 
 
 # ── Tool execution functions ─────────────────────────────────────────────────
+
 
 def run_validate_checkpoint(args: dict, pipeline: HeraldPipeline) -> dict:
     """Execute validate_checkpoint tool."""
@@ -314,7 +317,8 @@ def run_explain_verdict(args: dict) -> dict:
         "resolved_at_tier": packet.resolved_at_tier,
         "checkpoint_type": packet.checkpoint.checkpoint_type.value,
         "output_text": packet.checkpoint.output_text,
-        "source_context": packet.checkpoint.source_context[:500] + ("..." if len(packet.checkpoint.source_context) > 500 else ""),
+        "source_context": packet.checkpoint.source_context[:500]
+        + ("..." if len(packet.checkpoint.source_context) > 500 else ""),
         "tier_breakdown": {},
     }
 
@@ -391,7 +395,9 @@ def run_request_human_review(args: dict) -> dict:
 
     lean = "no clear lean"
     if t3:
-        lean = f"debate judge leaned '{t3.judge_verdict.value}' (confidence {t3.judge_confidence:.2f})"
+        lean = (
+            f"debate judge leaned '{t3.judge_verdict.value}' (confidence {t3.judge_confidence:.2f})"
+        )
     elif t2:
         lean = f"LLM judge returned '{t2.verdict.value}' with low confidence ({t2.confidence:.2f})"
 
@@ -455,11 +461,10 @@ def run_analyze_task(args: dict, anthropic_client: anthropic.Anthropic) -> dict:
 
 def run_validate_batch(args: dict, pipeline: HeraldPipeline) -> dict:
     """Execute validate_batch tool — Phase 2 batch validation."""
-    from herald.agent.batch import BatchValidator
-    from herald.core.types import (
-        CheckpointType, GeneratedOutput, TaskPlan
-    )
     import uuid
+
+    from herald.agent.batch import BatchValidator
+    from herald.core.types import CheckpointType, GeneratedOutput, TaskPlan
 
     # Build GeneratedOutput list
     outputs = []
@@ -471,20 +476,23 @@ def run_validate_batch(args: dict, pipeline: HeraldPipeline) -> dict:
                 suggested_ct = CheckpointType(ct_str)
             except ValueError:
                 pass
-        outputs.append(GeneratedOutput(
-            id=str(uuid.uuid4())[:8],
-            text=item["text"],
-            output_type=item.get("output_type", "output"),
-            references_section=item.get("references_section"),
-            suggested_checkpoint_type=suggested_ct,
-            metadata={},
-        ))
+        outputs.append(
+            GeneratedOutput(
+                id=str(uuid.uuid4())[:8],
+                text=item["text"],
+                output_type=item.get("output_type", "output"),
+                references_section=item.get("references_section"),
+                suggested_checkpoint_type=suggested_ct,
+                metadata={},
+            )
+        )
 
     # Build or default TaskPlan
     raw_plan = args.get("task_plan") or {}
     if raw_plan:
         try:
             from herald.agent.analyzer import TaskAnalyzer
+
             plan = TaskAnalyzer(client=None)._parse_plan(raw_plan)  # type: ignore[arg-type]
         except Exception:
             raw_plan = {}
@@ -523,7 +531,9 @@ def run_validate_batch(args: dict, pipeline: HeraldPipeline) -> dict:
             "note": (
                 "Call explain_verdict with any result_id from tier4_pending "
                 "to see the full evidence, then request_human_review to adjudicate."
-            ) if tier4_ids else None,
+            )
+            if tier4_ids
+            else None,
         }
     except Exception as exc:
         return {"error": str(exc)}
@@ -579,11 +589,12 @@ def run_generate_and_validate(
 
 # ── Dispatcher ───────────────────────────────────────────────────────────────
 
+
 def execute_tool(
     tool_name: str,
     tool_input: dict,
     pipeline: HeraldPipeline,
-    anthropic_client: Optional[anthropic.Anthropic] = None,
+    anthropic_client: anthropic.Anthropic | None = None,
 ) -> str:
     """Route a tool call to the right function and return JSON string result."""
     if tool_name == "validate_checkpoint":

--- a/src/herald/core/config.py
+++ b/src/herald/core/config.py
@@ -2,8 +2,9 @@
 
 import copy
 import os
-import yaml
 from pathlib import Path
+
+import yaml
 from dotenv import load_dotenv
 
 

--- a/src/herald/core/llm.py
+++ b/src/herald/core/llm.py
@@ -8,7 +8,6 @@ Usage:
     response = client.complete(prompt, json_mode=True, system=JUDGE_SYSTEM)
 """
 
-import json
 import os
 import re
 from dataclasses import dataclass
@@ -26,6 +25,7 @@ class GroqClient:
 
     def __init__(self, api_key: str, model: str):
         from groq import Groq
+
         self.client = Groq(api_key=api_key)
         self.model = model
         self.provider = "groq"
@@ -67,13 +67,21 @@ class GeminiClient:
     """
 
     # Models known not to support system_instruction or json_mode
-    _NO_SYSTEM_MODELS = {"gemma-3-1b-it", "gemma-3-4b-it", "gemma-3-12b-it",
-                         "gemma-3-27b-it", "gemma-3n-e4b-it", "gemma-3n-e2b-it",
-                         "gemma-4-26b-a4b-it", "gemma-4-31b-it"}
+    _NO_SYSTEM_MODELS = {
+        "gemma-3-1b-it",
+        "gemma-3-4b-it",
+        "gemma-3-12b-it",
+        "gemma-3-27b-it",
+        "gemma-3n-e4b-it",
+        "gemma-3n-e2b-it",
+        "gemma-4-26b-a4b-it",
+        "gemma-4-31b-it",
+    }
 
     def __init__(self, api_key: str, model: str):
         from google import genai
         from google.genai import types as genai_types
+
         self.client = genai.Client(api_key=api_key)
         self.model = model
         self.provider = "gemini"
@@ -112,7 +120,9 @@ class GeminiClient:
             config_kwargs["response_mime_type"] = "application/json"
 
         # For models without system support, merge system into prompt
-        effective_prompt = f"{system}\n\n{prompt}" if (system and not self._supports_system) else prompt
+        effective_prompt = (
+            f"{system}\n\n{prompt}" if (system and not self._supports_system) else prompt
+        )
 
         config = self._types.GenerateContentConfig(**config_kwargs)
         response = self.client.models.generate_content(
@@ -129,6 +139,7 @@ class OpenAIClient:
 
     def __init__(self, api_key: str, model: str):
         from openai import OpenAI
+
         self.client = OpenAI(api_key=api_key)
         self.model = model
         self.provider = "openai"

--- a/src/herald/core/types.py
+++ b/src/herald/core/types.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Literal, Optional
+from typing import Literal
 
 
 class Verdict(Enum):
@@ -23,6 +23,7 @@ class CheckpointType(Enum):
 @dataclass
 class TierResult:
     """Result from any single tier."""
+
     tier: int
     verdict: Verdict
     confidence: float
@@ -33,16 +34,18 @@ class TierResult:
 @dataclass
 class CounterfactualResult:
     """Result from Tier 2.5 counterfactual probe."""
-    disconfirming_condition: str   # What the model says would change its verdict
-    evidence_found: bool           # Whether that condition actually exists in the source
-    evidence_quote: str            # The relevant quote, or empty string if not found
-    verdict_overridden: bool       # True if a confident Tier 2 verdict was flipped to UNCERTAIN
-    reasoning: str                 # Probe's explanation
+
+    disconfirming_condition: str  # What the model says would change its verdict
+    evidence_found: bool  # Whether that condition actually exists in the source
+    evidence_quote: str  # The relevant quote, or empty string if not found
+    verdict_overridden: bool  # True if a confident Tier 2 verdict was flipped to UNCERTAIN
+    reasoning: str  # Probe's explanation
 
 
 @dataclass
 class DebateResult:
     """Result from Tier 3 multi-agent debate."""
+
     advocate_argument: str
     critic_argument: str
     judge_verdict: Verdict
@@ -53,6 +56,7 @@ class DebateResult:
 @dataclass
 class CheckpointOutput:
     """A single checkpoint output to be validated."""
+
     checkpoint_type: CheckpointType
     output_text: str
     source_context: str
@@ -63,28 +67,31 @@ class CheckpointOutput:
 @dataclass
 class EscalationPacket:
     """Full packet tracking a case through all tiers."""
+
     checkpoint: CheckpointOutput
-    tier1_result: Optional[TierResult] = None
-    tier2_result: Optional[TierResult] = None
-    tier2_5_result: Optional[CounterfactualResult] = None
-    tier3_result: Optional[DebateResult] = None
-    resolved_at_tier: Optional[int] = None
-    final_verdict: Optional[Verdict] = None
+    tier1_result: TierResult | None = None
+    tier2_result: TierResult | None = None
+    tier2_5_result: CounterfactualResult | None = None
+    tier3_result: DebateResult | None = None
+    resolved_at_tier: int | None = None
+    final_verdict: Verdict | None = None
 
 
 # ── Phase 0: Task Analysis types ────────────────────────────────────────────
 
+
 @dataclass
 class TaskPlan:
     """Output of Phase 0 task analysis."""
+
     expected_output_count: int | str  # exact number or "multiple", "single"
-    output_unit: str                  # e.g., "comment", "claim", "paragraph", "bullet point"
+    output_unit: str  # e.g., "comment", "claim", "paragraph", "bullet point"
     primary_checkpoint_types: list[CheckpointType]
     requires_source_mapping: bool
     task_nature: Literal["empirical", "subjective", "mixed"]
     evaluation_mode: Literal["exhaustive", "sampled", "adaptive"]
-    sample_size: Optional[int]        # If sampled, how many to validate
-    skip_nli_for: list[CheckpointType]          # Route straight to Tier 2 (NLI weak here)
+    sample_size: int | None  # If sampled, how many to validate
+    skip_nli_for: list[CheckpointType]  # Route straight to Tier 2 (NLI weak here)
     debate_recommended_for: list[CheckpointType]  # Benefit from multi-agent debate
     source_type: Literal["single_document", "multiple_documents", "conversation"]
     source_chunking: Literal["by_section", "by_page", "whole_document", "per_output"]
@@ -93,17 +100,19 @@ class TaskPlan:
 @dataclass
 class GeneratedOutput:
     """A single output from the research agent, ready for validation."""
+
     id: str
     text: str
-    output_type: str                          # e.g., "comment", "claim", "paragraph"
-    references_section: Optional[str]         # Which part of source this references
-    suggested_checkpoint_type: Optional[CheckpointType]
+    output_type: str  # e.g., "comment", "claim", "paragraph"
+    references_section: str | None  # Which part of source this references
+    suggested_checkpoint_type: CheckpointType | None
     metadata: dict = field(default_factory=dict)
 
 
 @dataclass
 class BatchValidationResult:
     """Results from batch validation of multiple outputs."""
+
     task_plan: TaskPlan
     total_outputs: int
     tier1_valid: list[tuple["GeneratedOutput", TierResult]]

--- a/src/herald/evaluation/evaluate.py
+++ b/src/herald/evaluation/evaluate.py
@@ -2,8 +2,8 @@
 
 import argparse
 import json
-from pathlib import Path
 from collections import defaultdict
+from pathlib import Path
 
 
 def main():
@@ -22,9 +22,14 @@ def main():
 
     # Accuracy
     stats = defaultdict(lambda: {"correct": 0, "total": 0})
-    for r, g in zip(results, gt):
+    for r, g in zip(results, gt, strict=False):
         match = r["final_verdict"] == g["label"]
-        for key in ["overall", f"cp_{r['checkpoint_type']}", f"tier_{r['resolved_at_tier']}", f"label_{g['label']}"]:
+        for key in [
+            "overall",
+            f"cp_{r['checkpoint_type']}",
+            f"tier_{r['resolved_at_tier']}",
+            f"label_{g['label']}",
+        ]:
             stats[key]["correct"] += int(match)
             stats[key]["total"] += 1
 
@@ -39,38 +44,44 @@ def main():
 
     # Print
     n = len(results)
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print("HERALD EVALUATION")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
 
     overall = stats["overall"]
-    print(f"\nOverall: {overall['correct']}/{overall['total']} ({overall['correct']/overall['total']:.1%})")
+    print(
+        f"\nOverall: {overall['correct']}/{overall['total']} ({overall['correct'] / overall['total']:.1%})"
+    )
 
     print("\nBy checkpoint type:")
     for k, v in sorted(stats.items()):
         if k.startswith("cp_"):
-            print(f"  {k[3:]:20s} {v['correct']}/{v['total']} ({v['correct']/v['total']:.1%})")
+            print(f"  {k[3:]:20s} {v['correct']}/{v['total']} ({v['correct'] / v['total']:.1%})")
 
     print("\nBy resolving tier:")
     for k, v in sorted(stats.items()):
         if k.startswith("tier_"):
-            print(f"  Tier {k[5:]:15s} {v['correct']}/{v['total']} ({v['correct']/v['total']:.1%})")
+            print(
+                f"  Tier {k[5:]:15s} {v['correct']}/{v['total']} ({v['correct'] / v['total']:.1%})"
+            )
 
-    print(f"\nEscalation rates:")
+    print("\nEscalation rates:")
     for tier in sorted(tier_counts):
-        print(f"  Tier {tier}: {tier_counts[tier]}/{n} ({tier_counts[tier]/n:.1%})")
+        print(f"  Tier {tier}: {tier_counts[tier]}/{n} ({tier_counts[tier] / n:.1%})")
 
-    print(f"\nCost (Groq = free for Tiers 1-3):")
-    print(f"  HERALD:          ${total_cost/n:.4f}/case")
-    print(f"  LLM-judge-all:   $0.00/case (Groq free tier)")
-    print(f"  Human-all:       $5.00/case")
-    print(f"  HERALD advantage: {sum(1 for r in results if r['resolved_at_tier'] < 4)}/{n} cases avoided human review")
+    print("\nCost (Groq = free for Tiers 1-3):")
+    print(f"  HERALD:          ${total_cost / n:.4f}/case")
+    print("  LLM-judge-all:   $0.00/case (Groq free tier)")
+    print("  Human-all:       $5.00/case")
+    print(
+        f"  HERALD advantage: {sum(1 for r in results if r['resolved_at_tier'] < 4)}/{n} cases avoided human review"
+    )
 
     # Save
     Path(args.output).parent.mkdir(parents=True, exist_ok=True)
     evaluation = {
-        "accuracy": {k: {"acc": v["correct"]/v["total"], **v} for k, v in stats.items()},
-        "escalation": {f"tier_{t}": {"count": c, "rate": c/n} for t, c in tier_counts.items()},
+        "accuracy": {k: {"acc": v["correct"] / v["total"], **v} for k, v in stats.items()},
+        "escalation": {f"tier_{t}": {"count": c, "rate": c / n} for t, c in tier_counts.items()},
         "cost_per_case": total_cost / n,
         "human_review_rate": tier_counts.get(4, 0) / n,
     }

--- a/src/herald/notebooks/feasibility_check.py
+++ b/src/herald/notebooks/feasibility_check.py
@@ -16,8 +16,7 @@ import sys
 from pathlib import Path
 
 import torch
-from transformers import AutoTokenizer, AutoModelForSequenceClassification
-
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
 SAMPLE_PATH = "data/test_sets/feasibility_samples.json"
 # Read from the loaded model's own config instead of a hardcoded constant
@@ -25,8 +24,12 @@ SAMPLE_PATH = "data/test_sets/feasibility_samples.json"
 
 def run_nli(model, tokenizer, premise: str, hypothesis: str, device: str, label_map: dict) -> dict:
     inputs = tokenizer(
-        premise, hypothesis,
-        return_tensors="pt", truncation=True, max_length=512, padding=True,
+        premise,
+        hypothesis,
+        return_tensors="pt",
+        truncation=True,
+        max_length=512,
+        padding=True,
     ).to(device)
     with torch.no_grad():
         probs = torch.softmax(model(**inputs).logits, dim=-1)[0]
@@ -38,7 +41,9 @@ def main():
     if not Path(SAMPLE_PATH).exists():
         print(f"ERROR: {SAMPLE_PATH} not found.\n")
         print("Create this file first. You can copy and expand data/test_sets/sample_cases.json")
-        print("Make sure each entry has: source_context, output_text, label (valid/invalid/ambiguous)")
+        print(
+            "Make sure each entry has: source_context, output_text, label (valid/invalid/ambiguous)"
+        )
         sys.exit(1)
 
     with open(SAMPLE_PATH) as f:
@@ -52,6 +57,7 @@ def main():
 
     # Load model — reads name from config so a single source of truth is maintained
     from herald.core.config import load_config
+
     try:
         cfg = load_config()
         model_name = cfg["tier1"]["model_name"]
@@ -71,16 +77,18 @@ def main():
     for i, s in enumerate(samples):
         scores = run_nli(model, tokenizer, s["source_context"], s["output_text"], device, label_map)
         label = s["label"]
-        print(f"[{i+1:3d}/{len(samples)}] {label:10s} | "
-              f"ent={scores['entailment']:.3f} con={scores['contradiction']:.3f} "
-              f"neu={scores['neutral']:.3f} | {s['output_text'][:55]}...")
+        print(
+            f"[{i + 1:3d}/{len(samples)}] {label:10s} | "
+            f"ent={scores['entailment']:.3f} con={scores['contradiction']:.3f} "
+            f"neu={scores['neutral']:.3f} | {s['output_text'][:55]}..."
+        )
         if label in results:
             results[label].append(scores)
 
     # Analysis
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print("FEASIBILITY RESULTS")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
 
     for label in ["valid", "invalid", "ambiguous"]:
         if not results[label]:
@@ -88,8 +96,12 @@ def main():
         ent = [s["entailment"] for s in results[label]]
         con = [s["contradiction"] for s in results[label]]
         print(f"\n{label.upper()} (n={len(results[label])})")
-        print(f"  Entailment:    avg={sum(ent)/len(ent):.3f}  min={min(ent):.3f}  max={max(ent):.3f}")
-        print(f"  Contradiction: avg={sum(con)/len(con):.3f}  min={min(con):.3f}  max={max(con):.3f}")
+        print(
+            f"  Entailment:    avg={sum(ent) / len(ent):.3f}  min={min(ent):.3f}  max={max(ent):.3f}"
+        )
+        print(
+            f"  Contradiction: avg={sum(con) / len(con):.3f}  min={min(con):.3f}  max={max(con):.3f}"
+        )
 
     # Key decision metric
     if results["valid"] and results["invalid"]:
@@ -98,31 +110,45 @@ def main():
         min_valid = min(v_ent)
         max_invalid = max(i_ent)
 
-        print(f"\n{'─'*60}")
+        print(f"\n{'─' * 60}")
         print("GO / NO-GO DECISION")
-        print(f"{'─'*60}")
+        print(f"{'─' * 60}")
         print(f"Min entailment (valid cases):   {min_valid:.3f}")
         print(f"Max entailment (invalid cases):  {max_invalid:.3f}")
 
         if min_valid > max_invalid:
-            print(f"\n✅ CLEAN SEPARATION — Tier 1 is feasible. Proceed to Phase 2.")
+            print("\n✅ CLEAN SEPARATION — Tier 1 is feasible. Proceed to Phase 2.")
         elif min_valid > max_invalid - 0.2:
-            print(f"\n⚠️  MODERATE OVERLAP ({max_invalid - min_valid:.3f}) — fine-tuning should fix this.")
+            print(
+                f"\n⚠️  MODERATE OVERLAP ({max_invalid - min_valid:.3f}) — fine-tuning should fix this."
+            )
         else:
-            print(f"\n❌ SIGNIFICANT OVERLAP ({max_invalid - min_valid:.3f}) — consider alternative Tier 1 approaches.")
+            print(
+                f"\n❌ SIGNIFICANT OVERLAP ({max_invalid - min_valid:.3f}) — consider alternative Tier 1 approaches."
+            )
 
     # Save — keys match what phase_gates.py --phase 1 expects
     Path("results").mkdir(exist_ok=True)
     with open("results/feasibility_results.json", "w") as f:
-        json.dump({"samples_count": len(samples), "model": model_name, "by_label": {
-            k: {
-                "count": len(v),
-                "mean_entailment": sum(s["entailment"] for s in v) / len(v) if v else 0,
-                "mean_contradiction": sum(s["contradiction"] for s in v) / len(v) if v else 0,
-            }
-            for k, v in results.items()
-        }}, f, indent=2)
-    print(f"\nSaved to results/feasibility_results.json")
+        json.dump(
+            {
+                "samples_count": len(samples),
+                "model": model_name,
+                "by_label": {
+                    k: {
+                        "count": len(v),
+                        "mean_entailment": sum(s["entailment"] for s in v) / len(v) if v else 0,
+                        "mean_contradiction": sum(s["contradiction"] for s in v) / len(v)
+                        if v
+                        else 0,
+                    }
+                    for k, v in results.items()
+                },
+            },
+            f,
+            indent=2,
+        )
+    print("\nSaved to results/feasibility_results.json")
 
 
 if __name__ == "__main__":

--- a/src/herald/pipeline/escalation.py
+++ b/src/herald/pipeline/escalation.py
@@ -5,13 +5,15 @@ stopping as soon as any tier resolves with sufficient confidence.
 """
 
 import logging
-from typing import Optional
+
 from herald.core.types import (
-    CheckpointOutput, EscalationPacket, Verdict,
+    CheckpointOutput,
+    EscalationPacket,
+    Verdict,
 )
 from herald.tier1.classifier import NLIClassifier
-from herald.tier2.judge import LLMJudge
 from herald.tier2.counterfactual import CounterfactualProbe
+from herald.tier2.judge import LLMJudge
 from herald.tier3.debate import MultiAgentDebate
 from herald.tier4.human_review import save_packet
 
@@ -34,7 +36,7 @@ class HeraldPipeline:
         tier3: MultiAgentDebate,
         t1_threshold: float = 0.70,
         t2_threshold: float = 0.80,
-        counterfactual_probe: Optional[CounterfactualProbe] = None,
+        counterfactual_probe: CounterfactualProbe | None = None,
     ):
         self.tier1 = tier1
         self.tier2 = tier2
@@ -72,9 +74,7 @@ class HeraldPipeline:
                     f"[Tier 2.5] Probing confident {t2.verdict.value} verdict "
                     f"({t2.confidence:.3f}) for disconfirming evidence"
                 )
-                cf = self.counterfactual_probe.probe(
-                    checkpoint, t2, t2_threshold=self.t2
-                )
+                cf = self.counterfactual_probe.probe(checkpoint, t2, t2_threshold=self.t2)
                 packet.tier2_5_result = cf
 
                 if cf.verdict_overridden:
@@ -133,12 +133,14 @@ def build_pipeline(config: dict) -> HeraldPipeline:
     cf_probe = None
     if config.get("counterfactual_probe", {}).get("enabled", False):
         provider = config.get("provider", "groq").lower()
-        api_key = config.get("groq_api_key", "") if provider == "groq" else config.get("gemini_api_key", "")
+        api_key = (
+            config.get("groq_api_key", "")
+            if provider == "groq"
+            else config.get("gemini_api_key", "")
+        )
         cf_probe = CounterfactualProbe(
             api_key=api_key,
-            model=config["counterfactual_probe"].get(
-                "model", config["tier2"]["model"]
-            ),
+            model=config["counterfactual_probe"].get("model", config["tier2"]["model"]),
         )
         logger.info("[Config] Tier 2.5 counterfactual probe enabled")
 

--- a/src/herald/pipeline/run.py
+++ b/src/herald/pipeline/run.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import logging
 from pathlib import Path
+
 from herald.core.cli import add_llm_override_args
 from herald.core.config import load_config
 from herald.core.types import CheckpointOutput, CheckpointType
@@ -16,7 +17,11 @@ def main():
     parser.add_argument("--config", default="configs/default.yaml")
     parser.add_argument("--output", default="results/run_results.json")
     parser.add_argument("-v", "--verbose", action="store_true")
-    parser.add_argument("--resume", action="store_true", help="Resume from existing output file (skip already-processed cases)")
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume from existing output file (skip already-processed cases)",
+    )
     add_llm_override_args(parser, include_tier2=True, include_tier3=True)
     args = parser.parse_args()
 
@@ -58,13 +63,13 @@ def main():
         start_index = len(results)
         print(f"Resuming from case {start_index + 1}/{len(cases)} ({start_index} already done)")
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"HERALD — Processing {len(cases)} cases (starting at {start_index + 1})")
     print(f"T1={config['thresholds']['T1']}  T2={config['thresholds']['T2']}")
-    print(f"{'='*60}\n")
+    print(f"{'=' * 60}\n")
 
     for i, case in enumerate(cases[start_index:], start=start_index):
-        print(f"Case {i+1}/{len(cases)}: [{case.checkpoint_type.value}]")
+        print(f"Case {i + 1}/{len(cases)}: [{case.checkpoint_type.value}]")
         packet = pipeline.validate(case)
 
         result = {
@@ -73,17 +78,26 @@ def main():
             "output_text": case.output_text[:80] + "...",
             "resolved_at_tier": packet.resolved_at_tier,
             "final_verdict": packet.final_verdict.value,
-            "tier1_confidence": round(packet.tier1_result.confidence, 3) if packet.tier1_result else None,
-            "tier2_confidence": round(packet.tier2_result.confidence, 3) if packet.tier2_result else None,
-            "tier3_confidence": round(packet.tier3_result.judge_confidence, 3) if packet.tier3_result else None,
+            "tier1_confidence": round(packet.tier1_result.confidence, 3)
+            if packet.tier1_result
+            else None,
+            "tier2_confidence": round(packet.tier2_result.confidence, 3)
+            if packet.tier2_result
+            else None,
+            "tier3_confidence": round(packet.tier3_result.judge_confidence, 3)
+            if packet.tier3_result
+            else None,
         }
         results.append(result)
 
         tier_label = f"Tier {packet.resolved_at_tier}"
         conf = (
-            packet.tier1_result.confidence if packet.resolved_at_tier == 1
-            else packet.tier2_result.confidence if packet.resolved_at_tier == 2 and packet.tier2_result
-            else packet.tier3_result.judge_confidence if packet.resolved_at_tier == 3 and packet.tier3_result
+            packet.tier1_result.confidence
+            if packet.resolved_at_tier == 1
+            else packet.tier2_result.confidence
+            if packet.resolved_at_tier == 2 and packet.tier2_result
+            else packet.tier3_result.judge_confidence
+            if packet.resolved_at_tier == 3 and packet.tier3_result
             else None
         )
         conf_str = f" ({conf:.3f})" if conf is not None else ""
@@ -94,9 +108,9 @@ def main():
             json.dump(results, f, indent=2)
 
     # Summary
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
     print("SUMMARY")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
 
     tier_counts = {1: 0, 2: 0, 3: 0, 4: 0}
     verdict_counts = {}
@@ -107,7 +121,7 @@ def main():
     n = len(results)
     for tier in [1, 2, 3, 4]:
         count = tier_counts.get(tier, 0)
-        print(f"  Tier {tier}: {count:3d}/{n} ({count/n*100:5.1f}%)")
+        print(f"  Tier {tier}: {count:3d}/{n} ({count / n * 100:5.1f}%)")
 
     print(f"\nVerdicts: {verdict_counts}")
     print(f"\nResults saved to {output_path}  ({n} cases)")

--- a/src/herald/tier1/classifier.py
+++ b/src/herald/tier1/classifier.py
@@ -8,8 +8,9 @@ Maps NLI labels to validation verdicts:
 """
 
 import torch
-from transformers import AutoTokenizer, AutoModelForSequenceClassification
-from herald.core.types import TierResult, Verdict, CheckpointOutput
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+from herald.core.types import CheckpointOutput, TierResult, Verdict
 
 
 class NLIClassifier:
@@ -82,7 +83,9 @@ class NLIClassifier:
         if not source_chunks:
             raise ValueError("source_chunks must not be empty")
 
-        all_scores = [self._get_nli_scores(chunk, checkpoint.output_text) for chunk in source_chunks]
+        all_scores = [
+            self._get_nli_scores(chunk, checkpoint.output_text) for chunk in source_chunks
+        ]
 
         if aggregation == "max_entailment":
             # Most generous: valid if any chunk entails it
@@ -102,7 +105,9 @@ class NLIClassifier:
             keys = ["entailment", "contradiction", "neutral"]
             agg = {k: sum(s[k] for s in all_scores) / len(all_scores) for k in keys}
         else:
-            raise ValueError(f"Unknown aggregation: {aggregation!r}. Use 'max_entailment', 'max_contradiction', or 'mean'.")
+            raise ValueError(
+                f"Unknown aggregation: {aggregation!r}. Use 'max_entailment', 'max_contradiction', or 'mean'."
+            )
 
         ent, con, neu = agg["entailment"], agg["contradiction"], agg["neutral"]
 
@@ -124,15 +129,20 @@ class NLIClassifier:
             tier=1,
             verdict=verdict,
             confidence=confidence,
-            reasoning=f"Multi-source NLI ({aggregation}, {len(source_chunks)} chunks): " + " | ".join(chunk_summary),
+            reasoning=f"Multi-source NLI ({aggregation}, {len(source_chunks)} chunks): "
+            + " | ".join(chunk_summary),
             raw_scores={**agg, "per_chunk": all_scores},
         )
 
     def _get_nli_scores(self, premise: str, hypothesis: str) -> dict:
         """Run NLI and return {entailment, contradiction, neutral} probabilities."""
         inputs = self.tokenizer(
-            premise, hypothesis,
-            return_tensors="pt", truncation=True, max_length=512, padding=True,
+            premise,
+            hypothesis,
+            return_tensors="pt",
+            truncation=True,
+            max_length=512,
+            padding=True,
         ).to(self.device)
 
         with torch.no_grad():

--- a/src/herald/tier2/counterfactual.py
+++ b/src/herald/tier2/counterfactual.py
@@ -36,8 +36,8 @@ import json
 import time
 
 from groq import Groq
-from herald.core.types import CounterfactualResult, TierResult, Verdict, CheckpointOutput
 
+from herald.core.types import CheckpointOutput, CounterfactualResult, TierResult
 
 PROBE_PROMPT = """You are performing a counterfactual validity check.
 
@@ -101,7 +101,6 @@ class CounterfactualProbe:
             reasoning=tier2_result.reasoning,
         )
 
-        last_err = None
         for attempt in range(max_retries):
             try:
                 response = self.client.chat.completions.create(
@@ -135,10 +134,9 @@ class CounterfactualProbe:
                 )
 
             except Exception as e:
-                last_err = e
                 if attempt < max_retries - 1:
                     time.sleep(retry_delay)
                 else:
                     raise RuntimeError(
                         f"Counterfactual probe failed after {max_retries} attempts: {e}"
-                    )
+                    ) from e

--- a/src/herald/tier2/judge.py
+++ b/src/herald/tier2/judge.py
@@ -6,9 +6,9 @@ Receives cases Tier 1 couldn't resolve with confidence.
 
 import json
 import math
-from herald.core.types import TierResult, Verdict, CheckpointOutput
-from herald.core.llm import get_llm_client
 
+from herald.core.llm import get_llm_client
+from herald.core.types import CheckpointOutput, TierResult, Verdict
 
 JUDGE_SYSTEM = """You are a strict validation judge for policy research outputs. \
 Your job is to catch errors, hallucinations, and unsupported claims — not to confirm them.
@@ -79,6 +79,7 @@ class LLMJudge:
         retry_delay: float = 2.0,
     ) -> TierResult:
         import time
+
         prompt = JUDGE_TEMPLATE.format(
             output_text=checkpoint.output_text,
             source_context=checkpoint.source_context,
@@ -116,4 +117,4 @@ class LLMJudge:
                 if attempt < max_retries - 1:
                     time.sleep(retry_delay)
                 else:
-                    raise RuntimeError(f"LLM API failed after {max_retries} attempts: {e}")
+                    raise RuntimeError(f"LLM API failed after {max_retries} attempts: {e}") from e

--- a/src/herald/tier3/debate.py
+++ b/src/herald/tier3/debate.py
@@ -6,9 +6,9 @@ Switch providers via config: provider: "groq" | "gemini" | "openai"
 """
 
 import json
-from herald.core.types import TierResult, Verdict, CheckpointOutput, DebateResult
-from herald.core.llm import get_llm_client
 
+from herald.core.llm import get_llm_client
+from herald.core.types import CheckpointOutput, DebateResult, TierResult, Verdict
 
 ADVOCATE_PROMPT = """You are the ADVOCATE in a validation debate. Argue that the agent's output IS valid and faithful to the source.
 
@@ -82,6 +82,7 @@ class MultiAgentDebate:
         retry_delay: float = 2.0,
     ) -> DebateResult:
         import time
+
         ctx = {
             "output_text": checkpoint.output_text,
             "source_context": checkpoint.source_context,
@@ -94,9 +95,7 @@ class MultiAgentDebate:
                 advocate = self.client.complete(
                     ADVOCATE_PROMPT.format(**ctx), temperature=0.3
                 ).content
-                critic = self.client.complete(
-                    CRITIC_PROMPT.format(**ctx), temperature=0.3
-                ).content
+                critic = self.client.complete(CRITIC_PROMPT.format(**ctx), temperature=0.3).content
                 judge_resp = self.client.complete(
                     DEBATE_JUDGE_PROMPT.format(
                         **ctx,
@@ -118,4 +117,4 @@ class MultiAgentDebate:
                 if attempt < max_retries - 1:
                     time.sleep(retry_delay)
                 else:
-                    raise RuntimeError(f"LLM API failed after {max_retries} attempts: {e}")
+                    raise RuntimeError(f"LLM API failed after {max_retries} attempts: {e}") from e

--- a/src/herald/tier4/human_review.py
+++ b/src/herald/tier4/human_review.py
@@ -7,6 +7,7 @@ adjudicates a specific question — not a blank validation task.
 import json
 from datetime import datetime
 from pathlib import Path
+
 from herald.core.types import EscalationPacket
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,12 @@
 # pytest configuration and shared fixtures
-import sys
 import os
+import sys
+
 import pytest
+
 
 @pytest.fixture(autouse=True)
 def add_src_to_path():
-    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
     yield
     sys.path.pop(0)

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,10 +1,14 @@
-import pytest
-from herald.tier1.classifier import NLIClassifier
 from herald.core.types import CheckpointOutput, CheckpointType
+from herald.tier1.classifier import NLIClassifier
+
 
 def test_nli_classifier_basic():
     classifier = NLIClassifier()
-    cp = CheckpointOutput(checkpoint_type=CheckpointType.CLAIM_EXTRACTION, output_text="Test claim", source_context="Source text")
+    cp = CheckpointOutput(
+        checkpoint_type=CheckpointType.CLAIM_EXTRACTION,
+        output_text="Test claim",
+        source_context="Source text",
+    )
     # This is a smoke test; just check that it runs and returns a TierResult
     result = classifier.classify(cp)
-    assert hasattr(result, 'verdict')
+    assert hasattr(result, "verdict")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,9 +6,10 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../s
 from herald.core.config import load_config
 from herald.core.llm import get_llm_client
 
+
 def test_load_config():
     config = load_config("configs/default.yaml")
-    assert 'tier1' in config
+    assert "tier1" in config
 
 
 def test_load_config_overrides():

--- a/tests/test_debate.py
+++ b/tests/test_debate.py
@@ -1,14 +1,30 @@
-import pytest
-from unittest.mock import MagicMock
-from herald.tier3.debate import MultiAgentDebate
+from unittest.mock import MagicMock, patch
+
 from herald.core.types import CheckpointOutput, CheckpointType, TierResult, Verdict
+from herald.tier3.debate import MultiAgentDebate
+
+MOCK_CONFIG = {"provider": "groq", "tier3": {"model": "fake-model"}}
+
 
 def test_debate_mock():
-    debate = MultiAgentDebate(api_key="fake-key")
+    with patch("herald.tier3.debate.get_llm_client", return_value=MagicMock()):
+        debate = MultiAgentDebate(MOCK_CONFIG)
+
+    mock_response = MagicMock()
+    mock_response.content = "some argument"
+    judge_response = MagicMock()
+    judge_response.content = (
+        '{"verdict": "valid", "confidence": 0.9, "reasoning": "ok",'
+        ' "advocate_strengths": "a", "critic_strengths": "b"}'
+    )
     debate.client = MagicMock()
-    debate._call = MagicMock(return_value="{\"verdict\": \"valid\", \"confidence\": 0.9, \"reasoning\": \"ok\"}")
-    cp = CheckpointOutput(checkpoint_type=CheckpointType.CLAIM_EXTRACTION, output_text="Test claim", source_context="Source text")
+    debate.client.complete.side_effect = [mock_response, mock_response, judge_response]
+    cp = CheckpointOutput(
+        checkpoint_type=CheckpointType.CLAIM_EXTRACTION,
+        output_text="Test claim",
+        source_context="Source text",
+    )
     t1 = TierResult(tier=1, verdict=Verdict.UNCERTAIN, confidence=0.5)
     t2 = TierResult(tier=2, verdict=Verdict.UNCERTAIN, confidence=0.5)
     result = debate.debate(cp, t1, t2)
-    assert hasattr(result, 'judge_verdict')
+    assert hasattr(result, "judge_verdict")

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,10 +1,35 @@
-import pytest
+import json
+
 from herald.evaluation.evaluate import main as eval_main
 
-def test_evaluation_script_runs(monkeypatch):
-    # This is a smoke test; just check that the script can be called
-    monkeypatch.setattr('sys.argv', ['evaluate.py', '--results', 'results/run_results.json', '--ground-truth', 'data/test_sets/sample_cases.json'])
-    try:
-        eval_main()
-    except SystemExit:
-        pass  # argparse may call sys.exit
+
+def test_evaluation_script_runs(monkeypatch, tmp_path):
+    # Build matching temp fixtures so the lengths always agree
+    gt = [{"label": "valid", "checkpoint_type": "claim_extraction"}]
+    results = [
+        {
+            "final_verdict": "valid",
+            "checkpoint_type": "claim_extraction",
+            "resolved_at_tier": 1,
+        }
+    ]
+    gt_file = tmp_path / "gt.json"
+    results_file = tmp_path / "results.json"
+    gt_file.write_text(json.dumps(gt))
+    results_file.write_text(json.dumps(results))
+
+    out_file = tmp_path / "eval_out.json"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "evaluate.py",
+            "--results",
+            str(results_file),
+            "--ground-truth",
+            str(gt_file),
+            "--output",
+            str(out_file),
+        ],
+    )
+    eval_main()
+    assert out_file.exists()

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -1,13 +1,28 @@
-import pytest
-from unittest.mock import MagicMock
-from herald.tier2.judge import LLMJudge
+from unittest.mock import MagicMock, patch
+
 from herald.core.types import CheckpointOutput, CheckpointType, TierResult, Verdict
+from herald.tier2.judge import LLMJudge
+
+MOCK_CONFIG = {"provider": "groq", "tier2": {"model": "fake-model"}}
+
 
 def test_llm_judge_mock():
-    judge = LLMJudge(api_key="fake-key")
+    with patch("herald.tier2.judge.get_llm_client", return_value=MagicMock()):
+        judge = LLMJudge(MOCK_CONFIG)
+
+    mock_response = MagicMock()
+    mock_response.content = (
+        '{"verdict": "valid", "confidence": 0.99, "reasoning": "ok", "key_issues": []}'
+    )
+    mock_response.provider = "groq"
     judge.client = MagicMock()
-    judge.client.chat.completions.create.return_value.choices = [type('obj', (object,), {'message': type('msg', (object,), {'content': '{"verdict": "VALID", "confidence": 0.9, "reasoning": "ok"}'})})]
-    cp = CheckpointOutput(checkpoint_type=CheckpointType.CLAIM_EXTRACTION, output_text="Test claim", source_context="Source text")
+    judge.client.complete.return_value = mock_response
+
+    cp = CheckpointOutput(
+        checkpoint_type=CheckpointType.CLAIM_EXTRACTION,
+        output_text="Test claim",
+        source_context="Source text",
+    )
     t1 = TierResult(tier=1, verdict=Verdict.UNCERTAIN, confidence=0.5)
     result = judge.judge(cp, t1)
     assert result.verdict == Verdict.VALID

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,14 +1,21 @@
-import pytest
+from unittest.mock import patch
+
 from herald.pipeline.escalation import HeraldPipeline
 from herald.tier1.classifier import NLIClassifier
 from herald.tier2.judge import LLMJudge
 from herald.tier3.debate import MultiAgentDebate
-from herald.core.types import CheckpointOutput, CheckpointType, TierResult, Verdict
+
+MOCK_CONFIG = {"provider": "groq", "tier2": {"model": "fake"}, "tier3": {"model": "fake"}}
+
 
 def test_pipeline_init():
-    pipeline = HeraldPipeline(
-        tier1=NLIClassifier(),
-        tier2=LLMJudge(api_key="fake-key"),
-        tier3=MultiAgentDebate(api_key="fake-key"),
-    )
-    assert hasattr(pipeline, 'validate')
+    with (
+        patch("herald.tier2.judge.get_llm_client"),
+        patch("herald.tier3.debate.get_llm_client"),
+    ):
+        pipeline = HeraldPipeline(
+            tier1=NLIClassifier(),
+            tier2=LLMJudge(MOCK_CONFIG),
+            tier3=MultiAgentDebate(MOCK_CONFIG),
+        )
+    assert hasattr(pipeline, "validate")

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,7 +1,10 @@
 from herald.core.types import CheckpointOutput, CheckpointType, TierResult, Verdict
 
+
 def test_types_instantiation():
-    cp = CheckpointOutput(checkpoint_type=CheckpointType.CLAIM_EXTRACTION, output_text="foo", source_context="bar")
+    cp = CheckpointOutput(
+        checkpoint_type=CheckpointType.CLAIM_EXTRACTION, output_text="foo", source_context="bar"
+    )
     t1 = TierResult(tier=1, verdict=Verdict.UNCERTAIN, confidence=0.5)
     assert cp.checkpoint_type == CheckpointType.CLAIM_EXTRACTION
     assert t1.verdict == Verdict.UNCERTAIN


### PR DESCRIPTION
- Auto-fix 62 ruff violations (unused imports, f-string cleanup, import sort)
- Manually fix 6 remaining: remove unused `last_err` vars, add `from e` to raise-in-except chains (B904), add strict= to zip() (B905)
- Update stale tests: constructors for LLMJudge/MultiAgentDebate now take config dict not api_key= — patch get_llm_client and mock client.complete
- Fix test_evaluation to use tmp_path fixtures instead of hardcoded file paths that no longer exist after results/ reorganization

## Description

<!-- What does this PR do? Link any related issues: "Closes #123" -->

## Type of change

- [ ] Bug fix
- [ ] New feature / tier improvement
- [ ] Prompt change (Tier 2 or Tier 3)
- [ ] Refactor / code quality
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD / infrastructure

## Checklist

### Before opening this PR
- [ ] `uv run pytest` passes locally
- [ ] Sanity-run on `data/test_sets/sample_cases.json` completes without errors
- [ ] No hardcoded API keys or secrets in changed files
- [ ] Branch targets the correct base repo (`gu-dsan6725/spring-2026-final-project-team_02`)

### If you changed a prompt (Tier 2 or Tier 3)
- [ ] Documented the **before** and **after** prompt text below
- [ ] Validated on a held-out set (include before/after metrics)
- [ ] Noted motivation for the change

### Prompt change details (fill in if applicable)

**Before:**
```
(paste old prompt)
```

**After:**
```
(paste new prompt)
```

**Metrics before / after:**
| Metric | Before | After |
|--------|--------|-------|
| Accuracy | | |
| Escalation rate | | |
| Tier resolved at | | |

## Notes for reviewers

<!-- Anything the reviewer should know: known edge cases, follow-up work, design decisions -->
