### PR TITLE
checkpoint-2.3: tier-1 local NLI service — DeBERTa inference + HERALD…

### DIFF
--- a/backend/src/policy_memo_agent/api/app.py
+++ b/backend/src/policy_memo_agent/api/app.py
@@ -26,7 +26,20 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     """
     logger.info("Starting policy-memo-agent backend...")
     # TODO checkpoint-0.x: initialize DB connection pool
-    # TODO checkpoint-1.x: load NLI model
+
+    # Load NLI model once at startup — Tier 1 of HERALD pipeline
+    from policy_memo_agent.services.nli_service import get_nli_service
+
+    nli_service = get_nli_service()
+    try:
+        nli_service.load()
+        logger.info("NLI model ready")
+    except Exception:
+        logger.exception(
+            "NLI model failed to load — Tier 1 evaluation will be unavailable. "
+            "Install transformers + torch (uv sync --extra nli) or set NLI_ONNX_MODEL_PATH."
+        )
+
     yield
     logger.info("Shutting down policy-memo-agent backend...")
     # TODO checkpoint-0.x: close DB connection pool

--- a/backend/src/policy_memo_agent/api/routes/health.py
+++ b/backend/src/policy_memo_agent/api/routes/health.py
@@ -31,12 +31,18 @@ async def health_check() -> JSONResponse:
 @router.get("/nli", status_code=status.HTTP_200_OK)
 async def nli_health() -> JSONResponse:
     """Checks whether the NLI model is loaded and ready."""
-    # NLI model loading is implemented in checkpoint-1.x (tier1_nli.py).
-    # Until then, report the model as not yet loaded.
+    from policy_memo_agent.services.nli_service import get_nli_service
+
+    service = get_nli_service()
+    if service.is_loaded():
+        return JSONResponse(content={"status": "ok", "message": "NLI model is loaded and ready."})
     return JSONResponse(
         content={
             "status": "not_loaded",
-            "message": "NLI model will be loaded in checkpoint-1.x",
+            "message": (
+                "NLI model is not loaded. "
+                "Install transformers + torch (uv sync --extra nli) or set NLI_ONNX_MODEL_PATH."
+            ),
         },
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
     )

--- a/backend/src/policy_memo_agent/api/routes/herald.py
+++ b/backend/src/policy_memo_agent/api/routes/herald.py
@@ -1,26 +1,132 @@
-"""HERALD evaluation endpoints — stub implementation, returns 501 until checkpoint-3.x."""
+"""HERALD evaluation endpoints."""
 
 from __future__ import annotations
 
-from fastapi import APIRouter, status
-from fastapi.responses import JSONResponse
+import logging
+from typing import Annotated
 
-router = APIRouter(prefix="/herald", tags=["herald"])
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
 
-_NOT_IMPLEMENTED = JSONResponse(
-    status_code=status.HTTP_501_NOT_IMPLEMENTED,
-    content={
-        "error": "not_implemented",
-        "message": "HERALD endpoints will be implemented in checkpoint-3.x",
-    },
-)
+from policy_memo_agent.services.nli_service import NLIResult, NLIService, get_nli_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/herald", tags=["herald"])
+
+
+# ---------------------------------------------------------------------------
+# Dependency helpers
+# ---------------------------------------------------------------------------
+
+
+def _nli_service(service: Annotated[NLIService, Depends(get_nli_service)]) -> NLIService:
+    """Raise 503 if the NLI model has not been loaded yet."""
+    if not service.is_loaded():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="NLI model is not loaded. Check /health/nli for status.",
+        )
+    return service
+
+
+LoadedNLI = Annotated[NLIService, Depends(_nli_service)]
+
+
+# ---------------------------------------------------------------------------
+# Request / response schemas
+# ---------------------------------------------------------------------------
+
+
+class NLIPair(BaseModel):
+    premise: str
+    hypothesis: str
+
+
+class NLIScores(BaseModel):
+    entailment: float
+    neutral: float
+    contradiction: float
+
+
+class NLIResponse(BaseModel):
+    label: str
+    scores: NLIScores
+
+
+class NLIBatchRequest(BaseModel):
+    pairs: list[NLIPair]
+
+
+class NLIBatchResponse(BaseModel):
+    results: list[NLIResponse]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_response(result: NLIResult) -> NLIResponse:
+    return NLIResponse(
+        label=result.label,
+        scores=NLIScores(
+            entailment=result.scores.get("entailment", 0.0),
+            neutral=result.scores.get("neutral", 0.0),
+            contradiction=result.scores.get("contradiction", 0.0),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/nli", response_model=NLIResponse)
+async def nli_single(body: NLIPair, service: LoadedNLI) -> NLIResponse:
+    """
+    Run NLI inference on a single premise-hypothesis pair.
+
+    - **premise**: source chunk that supposedly supports the claim
+    - **hypothesis**: the claim text being evaluated
+    """
+    logger.debug("NLI single: premise_len=%d hyp_len=%d", len(body.premise), len(body.hypothesis))
+    result = service.predict(body.premise, body.hypothesis)
+    return _to_response(result)
+
+
+@router.post("/nli/batch", response_model=NLIBatchResponse)
+async def nli_batch(body: NLIBatchRequest, service: LoadedNLI) -> NLIBatchResponse:
+    """
+    Run NLI inference on a batch of premise-hypothesis pairs.
+
+    More efficient than calling /nli in a loop when a claim has multiple sources.
+    """
+    if not body.pairs:
+        return NLIBatchResponse(results=[])
+
+    logger.debug("NLI batch: %d pairs", len(body.pairs))
+    pairs = [(p.premise, p.hypothesis) for p in body.pairs]
+    results = service.predict_batch(pairs)
+    return NLIBatchResponse(results=[_to_response(r) for r in results])
+
+
+# ---------------------------------------------------------------------------
+# Legacy stubs (retained for future checkpoints)
+# ---------------------------------------------------------------------------
+
+_NOT_IMPLEMENTED_MSG = {
+    "error": "not_implemented",
+    "message": "This HERALD endpoint will be implemented in a future checkpoint.",
+}
 
 
 @router.post("/evaluate")
-async def evaluate_claims() -> JSONResponse:
-    return _NOT_IMPLEMENTED
+async def evaluate_claims() -> dict[str, str]:
+    raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail=_NOT_IMPLEMENTED_MSG)
 
 
 @router.get("/results/{memo_id}")
-async def get_results(_memo_id: str) -> JSONResponse:
-    return _NOT_IMPLEMENTED
+async def get_results(_memo_id: str) -> dict[str, str]:
+    raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail=_NOT_IMPLEMENTED_MSG)

--- a/backend/src/policy_memo_agent/services/nli_service.py
+++ b/backend/src/policy_memo_agent/services/nli_service.py
@@ -1,0 +1,284 @@
+"""
+NLI (Natural Language Inference) service - Tier 1 of the HERALD evaluation pipeline.
+
+Uses DeBERTa-v3-large-mnli via Hugging Face Transformers (CPU by default) or
+ONNX Runtime when NLI_ONNX_MODEL_PATH is set in the environment.
+
+The model is loaded ONCE on application startup via the FastAPI lifespan handler.
+It is NEVER replaced by an LLM call - this is the cheap, local filter that
+prevents unnecessary Anthropic API calls in Tiers 2-3.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_HF_MODEL = "microsoft/deberta-v3-large-mnli"
+
+# Normalise labels that differ by case or by numeric LABEL_N scheme.
+# microsoft/deberta-v3-large-mnli id2label: {0: CONTRADICTION, 1: NEUTRAL, 2: ENTAILMENT}
+_LABEL_NORMALISE: dict[str, str] = {
+    "entailment": "entailment",
+    "neutral": "neutral",
+    "contradiction": "contradiction",
+    "ENTAILMENT": "entailment",
+    "NEUTRAL": "neutral",
+    "CONTRADICTION": "contradiction",
+    # Numeric labels used by some ONNX exports
+    "LABEL_0": "contradiction",
+    "LABEL_1": "neutral",
+    "LABEL_2": "entailment",
+}
+
+
+@dataclass
+class NLIResult:
+    """Result from a single premise-hypothesis NLI inference."""
+
+    label: str  # "entailment" | "neutral" | "contradiction"
+    scores: dict[str, float] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Module-level parsing helper (importable for unit tests)
+# ---------------------------------------------------------------------------
+
+
+def _parse_hf_output(raw: object) -> NLIResult:
+    """
+    Normalise HuggingFace pipeline output into NLIResult.
+
+    With top_k=None the pipeline returns a list of dicts for each input:
+      [{"label": "ENTAILMENT", "score": 0.9}, {"label": "NEUTRAL", ...}, ...]
+
+    With top_k=1 it returns a single dict:
+      {"label": "ENTAILMENT", "score": 0.9}
+    """
+    if isinstance(raw, dict):
+        items: list[dict[str, object]] = [raw]  # type: ignore[list-item]
+    else:
+        items = list(raw)  # type: ignore[arg-type]
+
+    scores: dict[str, float] = {}
+    for item in items:
+        label_raw: str = str(item["label"])
+        score: float = float(str(item["score"]))
+        normalised = _LABEL_NORMALISE.get(label_raw, label_raw.lower())
+        scores[normalised] = score
+
+    # Ensure all three canonical labels are always present
+    for lbl in ("entailment", "neutral", "contradiction"):
+        scores.setdefault(lbl, 0.0)
+
+    best_label = max(scores, key=lambda k: scores[k])
+    return NLIResult(label=best_label, scores=scores)
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class NLIService:
+    """
+    Wraps either a HuggingFace Transformers pipeline or an ONNX Runtime session
+    to provide NLI inference for HERALD Tier 1.
+
+    Usage
+    -----
+    service = NLIService()
+    service.load()                       # called once at startup
+    result = service.predict(premise, hypothesis)
+    """
+
+    def __init__(self) -> None:
+        self._pipeline: object | None = None
+        self._ort_session: object | None = None
+        self._tokenizer: object | None = None
+        self._use_onnx: bool = False
+        self._loaded: bool = False
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def load(self) -> None:
+        """
+        Load the NLI model.  Called once at app startup.
+
+        Resolution order:
+        1. If NLI_ONNX_MODEL_PATH is set -> load ONNX model + tokenizer from that path.
+        2. Otherwise -> load HuggingFace pipeline for the model at HF_MODEL_PATH
+           (defaults to 'microsoft/deberta-v3-large-mnli').
+        """
+        onnx_path = os.getenv("NLI_ONNX_MODEL_PATH")
+        if onnx_path:
+            self._load_onnx(onnx_path)
+        else:
+            self._load_hf()
+        self._loaded = True
+        logger.info("NLI model loaded (onnx=%s)", self._use_onnx)
+
+    def is_loaded(self) -> bool:
+        """Return True once load() has completed successfully."""
+        return self._loaded
+
+    def predict(self, premise: str, hypothesis: str) -> NLIResult:
+        """
+        Run NLI inference for a single premise-hypothesis pair.
+
+        Parameters
+        ----------
+        premise:    The source chunk that supposedly supports the claim.
+        hypothesis: The claim text being evaluated.
+        """
+        if not self._loaded:
+            msg = "NLIService.predict() called before load()"
+            raise RuntimeError(msg)
+
+        if self._use_onnx:
+            return self._predict_onnx(premise, hypothesis)
+        return self._predict_hf(premise, hypothesis)
+
+    def predict_batch(self, pairs: list[tuple[str, str]]) -> list[NLIResult]:
+        """
+        Run NLI inference on a batch of (premise, hypothesis) pairs.
+        Falls back to sequential calls when using ONNX (no native batching).
+        """
+        if not self._loaded:
+            msg = "NLIService.predict_batch() called before load()"
+            raise RuntimeError(msg)
+
+        if self._use_onnx:
+            return [self._predict_onnx(p, h) for p, h in pairs]
+        return self._predict_hf_batch(pairs)
+
+    # ------------------------------------------------------------------
+    # HuggingFace Transformers backend
+    # ------------------------------------------------------------------
+
+    def _load_hf(self) -> None:
+        try:
+            from transformers import pipeline  # type: ignore[import-untyped]
+        except ImportError as exc:
+            msg = (
+                "transformers is not installed. "
+                "Run: uv sync --extra nli  (or install transformers + torch manually)."
+            )
+            raise ImportError(msg) from exc
+
+        model_name = os.getenv("HF_MODEL_PATH", _DEFAULT_HF_MODEL)
+        logger.info("Loading HuggingFace NLI pipeline: %s", model_name)
+
+        device = self._detect_device()
+        self._pipeline = pipeline(
+            "text-classification",
+            model=model_name,
+            device=device,
+            top_k=None,  # return all labels with scores
+        )
+        self._use_onnx = False
+
+    def _predict_hf(self, premise: str, hypothesis: str) -> NLIResult:
+        raw = self._pipeline(premise, text_pair=hypothesis)  # type: ignore[operator]
+        return _parse_hf_output(raw)
+
+    def _predict_hf_batch(self, pairs: list[tuple[str, str]]) -> list[NLIResult]:
+        # Hugging Face pipeline accepts list of (text, text_pair) dicts
+        inputs = [{"text": p, "text_pair": h} for p, h in pairs]
+        raw_batch = self._pipeline(inputs)  # type: ignore[operator]
+        return [_parse_hf_output(r) for r in raw_batch]
+
+    # ------------------------------------------------------------------
+    # ONNX Runtime backend
+    # ------------------------------------------------------------------
+
+    def _load_onnx(self, model_dir: str) -> None:
+        """Load a quantised ONNX model and its tokenizer from *model_dir*."""
+        try:
+            import onnxruntime as ort  # type: ignore[import-untyped]
+            from transformers import AutoTokenizer  # type: ignore[import-untyped]
+        except ImportError as exc:
+            msg = "onnxruntime and/or transformers are not installed. Run: uv sync --extra nli."
+            raise ImportError(msg) from exc
+
+        import pathlib
+
+        model_path = pathlib.Path(model_dir)
+        onnx_file = model_path / "model.onnx"
+        if not onnx_file.exists():
+            msg = f"ONNX model file not found: {onnx_file}"
+            raise FileNotFoundError(msg)
+
+        logger.info("Loading ONNX NLI model from %s", onnx_file)
+        sess_options = ort.SessionOptions()
+        sess_options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+        self._ort_session = ort.InferenceSession(
+            str(onnx_file),
+            sess_options=sess_options,
+            providers=["CPUExecutionProvider"],
+        )
+
+        tokenizer_name = os.getenv("HF_MODEL_PATH", _DEFAULT_HF_MODEL)
+        self._tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+        self._use_onnx = True
+
+    def _predict_onnx(self, premise: str, hypothesis: str) -> NLIResult:
+        import numpy as np  # type: ignore[import-untyped]
+
+        tokenizer = self._tokenizer
+        session = self._ort_session
+
+        encoding = tokenizer(  # type: ignore[operator]
+            premise,
+            hypothesis,
+            return_tensors="np",
+            truncation=True,
+            max_length=512,
+            padding=True,
+        )
+        inputs = {k: v.astype(np.int64) for k, v in encoding.items()}
+        logits = session.run(None, inputs)[0][0]  # type: ignore[union-attr]  # shape: (3,)
+
+        # Softmax to get probabilities
+        exp_logits = np.exp(logits - np.max(logits))
+        probs = (exp_logits / exp_logits.sum()).tolist()
+
+        # label order: 0=CONTRADICTION, 1=NEUTRAL, 2=ENTAILMENT
+        label_order = ["contradiction", "neutral", "entailment"]
+        scores = {label_order[i]: float(probs[i]) for i in range(len(label_order))}
+        best_label = max(scores, key=lambda k: scores[k])
+        return NLIResult(label=best_label, scores=scores)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _detect_device() -> int:
+        """Return 0 for CUDA GPU if available, else -1 for CPU."""
+        try:
+            import torch  # type: ignore[import-untyped]
+
+            return 0 if torch.cuda.is_available() else -1
+        except ImportError:
+            return -1
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton - acquired by the FastAPI lifespan handler
+# ---------------------------------------------------------------------------
+
+_service_instance: NLIService | None = None
+
+
+def get_nli_service() -> NLIService:
+    """Return the module-level NLI service singleton (must be loaded first)."""
+    global _service_instance
+    if _service_instance is None:
+        _service_instance = NLIService()
+    return _service_instance

--- a/backend/tests/test_herald/test_tier1_nli.py
+++ b/backend/tests/test_herald/test_tier1_nli.py
@@ -1,0 +1,327 @@
+"""
+HERALD Tier 1 NLI tests.
+
+Test groups
+-----------
+Unit tests (fast, no model required)
+  - NLIService raises before load()
+  - _parse_hf_output normalises labels correctly
+  - HTTP endpoint returns 503 when model is not loaded
+  - HTTP endpoint returns correct structure when model is mocked
+
+Slow / integration tests (@pytest.mark.tier1 @pytest.mark.slow)
+  - Real model loads successfully
+  - Entailment: "The unemployment rate is 5.2%" + "Unemployment is at 5.2%"
+  - Contradiction: "GDP grew by 3%" + "GDP shrank by 3%"
+  - Neutral: "The program was implemented in 2020" + "The program was successful"
+  - Batch endpoint returns consistent results with single-pair endpoint
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from policy_memo_agent.services.nli_service import NLIResult, NLIService, _parse_hf_output
+
+# ---------------------------------------------------------------------------
+# Unit tests — no model needed
+# ---------------------------------------------------------------------------
+
+
+class TestNLIServiceBeforeLoad:
+    def test_is_loaded_false_before_load(self) -> None:
+        service = NLIService()
+        assert service.is_loaded() is False
+
+    def test_predict_raises_before_load(self) -> None:
+        service = NLIService()
+        with pytest.raises(RuntimeError, match="called before load"):
+            service.predict("some premise", "some hypothesis")
+
+    def test_predict_batch_raises_before_load(self) -> None:
+        service = NLIService()
+        with pytest.raises(RuntimeError, match="called before load"):
+            service.predict_batch([("p", "h")])
+
+
+class TestParseHFOutput:
+    """Unit tests for the static label-normalisation helper."""
+
+    def test_uppercase_labels(self) -> None:
+        raw = [
+            {"label": "ENTAILMENT", "score": 0.9},
+            {"label": "NEUTRAL", "score": 0.06},
+            {"label": "CONTRADICTION", "score": 0.04},
+        ]
+        result = _parse_hf_output(raw)
+        assert result.label == "entailment"
+        assert abs(result.scores["entailment"] - 0.9) < 1e-6
+
+    def test_lowercase_labels(self) -> None:
+        raw = [
+            {"label": "contradiction", "score": 0.8},
+            {"label": "neutral", "score": 0.1},
+            {"label": "entailment", "score": 0.1},
+        ]
+        result = _parse_hf_output(raw)
+        assert result.label == "contradiction"
+
+    def test_numeric_labels(self) -> None:
+        # LABEL_0=contradiction, LABEL_1=neutral, LABEL_2=entailment
+        raw = [
+            {"label": "LABEL_2", "score": 0.95},
+            {"label": "LABEL_1", "score": 0.03},
+            {"label": "LABEL_0", "score": 0.02},
+        ]
+        result = _parse_hf_output(raw)
+        assert result.label == "entailment"
+        assert result.scores["entailment"] == pytest.approx(0.95)
+
+    def test_single_dict_input(self) -> None:
+        """pipeline with top_k=1 returns a single dict, not a list."""
+        raw = {"label": "NEUTRAL", "score": 0.7}
+        result = _parse_hf_output(raw)
+        assert result.label == "neutral"
+
+    def test_all_three_keys_always_present(self) -> None:
+        raw = [{"label": "ENTAILMENT", "score": 1.0}]
+        result = _parse_hf_output(raw)
+        assert "entailment" in result.scores
+        assert "neutral" in result.scores
+        assert "contradiction" in result.scores
+
+
+class TestNLIServiceWithMockedPipeline:
+    """Fast tests that verify NLIService logic without actually loading the model."""
+
+    def _make_loaded_service(self, mock_output: list[list[dict[str, object]]]) -> NLIService:
+        """Return an NLIService whose _pipeline is mocked to return mock_output."""
+        service = NLIService()
+        # Simulate load() without hitting disk
+        mock_pipeline = MagicMock(side_effect=mock_output)
+        service._pipeline = mock_pipeline
+        service._loaded = True
+        service._use_onnx = False
+        return service
+
+    def test_predict_entailment(self) -> None:
+        mock_out = [
+            [
+                {"label": "ENTAILMENT", "score": 0.95},
+                {"label": "NEUTRAL", "score": 0.03},
+                {"label": "CONTRADICTION", "score": 0.02},
+            ]
+        ]
+        service = self._make_loaded_service(mock_out)
+        result = service.predict("The rate is 5%.", "The rate is 5%.")
+        assert result.label == "entailment"
+        assert result.scores["entailment"] == pytest.approx(0.95)
+
+    def test_predict_contradiction(self) -> None:
+        mock_out = [
+            [
+                {"label": "CONTRADICTION", "score": 0.91},
+                {"label": "NEUTRAL", "score": 0.05},
+                {"label": "ENTAILMENT", "score": 0.04},
+            ]
+        ]
+        service = self._make_loaded_service(mock_out)
+        result = service.predict("GDP grew by 3%.", "GDP shrank by 3%.")
+        assert result.label == "contradiction"
+
+    def test_predict_batch_returns_list(self) -> None:
+        mock_out = [
+            [
+                [
+                    {"label": "ENTAILMENT", "score": 0.9},
+                    {"label": "NEUTRAL", "score": 0.06},
+                    {"label": "CONTRADICTION", "score": 0.04},
+                ],
+                [
+                    {"label": "NEUTRAL", "score": 0.7},
+                    {"label": "ENTAILMENT", "score": 0.2},
+                    {"label": "CONTRADICTION", "score": 0.1},
+                ],
+            ]
+        ]
+        service = self._make_loaded_service(mock_out)
+        results = service.predict_batch([("p1", "h1"), ("p2", "h2")])
+        assert len(results) == 2
+        assert results[0].label == "entailment"
+        assert results[1].label == "neutral"
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests — mock the NLI service
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture()
+async def client_with_mock_nli() -> AsyncClient:
+    """FastAPI test client with NLI service replaced by a mock via dependency_overrides."""
+    from policy_memo_agent.api.app import create_app
+    from policy_memo_agent.services.nli_service import get_nli_service
+
+    mock_service = MagicMock(spec=NLIService)
+    mock_service.is_loaded.return_value = True
+    mock_service.predict.return_value = NLIResult(
+        label="entailment",
+        scores={"entailment": 0.92, "neutral": 0.05, "contradiction": 0.03},
+    )
+    mock_service.predict_batch.return_value = [
+        NLIResult(
+            label="entailment",
+            scores={"entailment": 0.92, "neutral": 0.05, "contradiction": 0.03},
+        )
+    ]
+
+    app = create_app()
+    # FastAPI dependency override — bypasses the real singleton entirely
+    app.dependency_overrides[get_nli_service] = lambda: mock_service
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),  # type: ignore[arg-type]
+        base_url="http://test",
+    ) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_nli_single_endpoint_ok(client_with_mock_nli: AsyncClient) -> None:
+    response = await client_with_mock_nli.post(
+        "/api/herald/nli",
+        json={"premise": "The rate is 5%.", "hypothesis": "Unemployment is 5%."},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["label"] == "entailment"
+    assert "scores" in data
+    assert set(data["scores"].keys()) == {"entailment", "neutral", "contradiction"}
+
+
+@pytest.mark.asyncio
+async def test_nli_batch_endpoint_ok(client_with_mock_nli: AsyncClient) -> None:
+    response = await client_with_mock_nli.post(
+        "/api/herald/nli/batch",
+        json={"pairs": [{"premise": "The rate is 5%.", "hypothesis": "Unemployment is 5%."}]},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "results" in data
+    assert len(data["results"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_nli_batch_empty_pairs(client_with_mock_nli: AsyncClient) -> None:
+    response = await client_with_mock_nli.post(
+        "/api/herald/nli/batch",
+        json={"pairs": []},
+    )
+    assert response.status_code == 200
+    assert response.json()["results"] == []
+
+
+@pytest.mark.asyncio
+async def test_nli_endpoint_503_when_not_loaded() -> None:
+    """NLI service returns 503 when model has not been loaded."""
+    from policy_memo_agent.api.app import create_app
+    from policy_memo_agent.services.nli_service import get_nli_service
+
+    mock_service = MagicMock(spec=NLIService)
+    mock_service.is_loaded.return_value = False
+
+    app = create_app()
+    app.dependency_overrides[get_nli_service] = lambda: mock_service
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),  # type: ignore[arg-type]
+        base_url="http://test",
+    ) as client:
+        response = await client.post(
+            "/api/herald/nli",
+            json={"premise": "p", "hypothesis": "h"},
+        )
+
+    app.dependency_overrides.clear()
+    assert response.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Slow / real-model tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def loaded_nli_service() -> NLIService:
+    """Load the real DeBERTa model once per module (expensive — ~30-60s)."""
+    service = NLIService()
+    service.load()
+    return service
+
+
+@pytest.mark.tier1
+@pytest.mark.slow
+def test_model_loads_successfully(loaded_nli_service: NLIService) -> None:
+    assert loaded_nli_service.is_loaded() is True
+
+
+@pytest.mark.tier1
+@pytest.mark.slow
+def test_entailment_detection(loaded_nli_service: NLIService) -> None:
+    result = loaded_nli_service.predict(
+        premise="The unemployment rate is 5.2%.",
+        hypothesis="Unemployment is at 5.2%.",
+    )
+    assert result.label == "entailment", (
+        f"Expected entailment, got {result.label}. Scores: {result.scores}"
+    )
+    assert result.scores["entailment"] > 0.5
+
+
+@pytest.mark.tier1
+@pytest.mark.slow
+def test_contradiction_detection(loaded_nli_service: NLIService) -> None:
+    result = loaded_nli_service.predict(
+        premise="GDP grew by 3%.",
+        hypothesis="GDP shrank by 3%.",
+    )
+    assert result.label == "contradiction", (
+        f"Expected contradiction, got {result.label}. Scores: {result.scores}"
+    )
+    assert result.scores["contradiction"] > 0.5
+
+
+@pytest.mark.tier1
+@pytest.mark.slow
+def test_neutral_detection(loaded_nli_service: NLIService) -> None:
+    result = loaded_nli_service.predict(
+        premise="The program was implemented in 2020.",
+        hypothesis="The program was successful.",
+    )
+    assert result.label == "neutral", (
+        f"Expected neutral, got {result.label}. Scores: {result.scores}"
+    )
+    assert result.scores["neutral"] > 0.3
+
+
+@pytest.mark.tier1
+@pytest.mark.slow
+def test_batch_consistent_with_single(loaded_nli_service: NLIService) -> None:
+    """Batch inference must return the same labels as individual calls."""
+    pairs = [
+        ("The unemployment rate is 5.2%.", "Unemployment is at 5.2%."),
+        ("GDP grew by 3%.", "GDP shrank by 3%."),
+    ]
+    batch_results = loaded_nli_service.predict_batch(pairs)
+    single_results = [loaded_nli_service.predict(p, h) for p, h in pairs]
+
+    for i, (batch, single) in enumerate(zip(batch_results, single_results, strict=True)):
+        assert batch.label == single.label, (
+            f"Mismatch at pair {i}: batch={batch.label} single={single.label}"
+        )

--- a/src/herald/router.ts
+++ b/src/herald/router.ts
@@ -1,0 +1,151 @@
+/**
+ * HERALD claim router.
+ *
+ * Determines the starting HERALD tier for a claim based on its claim_type,
+ * then runs the evaluation pipeline with proper tier escalation.
+ *
+ * Routing table (mirrors CLAUDE.md and CLAIM_TYPE_CONFIG):
+ *
+ *   statistical  → Tier 1, NLI threshold 0.90
+ *   comparative  → Tier 1, NLI threshold 0.90
+ *   causal       → Tier 1, NLI threshold 0.85 (lower bar)
+ *   predictive   → skip to Tier 2  (NLI cannot evaluate projections)
+ *   normative    → skip to Tier 2  (NLI cannot evaluate prescriptions)
+ *   synthesis    → skip to Tier 2  (no single source entails synthesis)
+ */
+
+import { CLAIM_TYPE_CONFIG, type ClaimType, type NotesLogEntry } from '../types/claims';
+import type { HeraldResult, TierOutput } from '../types/herald';
+import { evaluateWithNLI } from './tier1-nli';
+
+// ---------------------------------------------------------------------------
+// Tier routing
+// ---------------------------------------------------------------------------
+
+export interface RouteDecision {
+  startTier: 1 | 2;
+  skipNLI: boolean;
+  nliThreshold: number | null;
+  rationale: string;
+}
+
+/** Determine which tier a claim should start evaluation at. */
+export function routeClaim(claim: NotesLogEntry): RouteDecision {
+  const config = CLAIM_TYPE_CONFIG[claim.claim_type];
+  if (config.skipNLI) {
+    return {
+      startTier: 2,
+      skipNLI: true,
+      nliThreshold: null,
+      rationale: `Claim type '${claim.claim_type}' skips NLI — starting at Tier 2.`,
+    };
+  }
+  return {
+    startTier: 1,
+    skipNLI: false,
+    nliThreshold: config.nliEscalationThreshold,
+    rationale:
+      `Claim type '${claim.claim_type}' starts at Tier 1 ` +
+      `(NLI threshold: ${(config.nliEscalationThreshold ?? 0.9) * 100}%).`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2 stub
+// ---------------------------------------------------------------------------
+
+/**
+ * Tier 2 LLM-as-Judge placeholder — will be implemented in a future checkpoint.
+ * Returns an uncertain verdict so callers know to treat results as incomplete.
+ */
+async function _tier2Stub(claim: NotesLogEntry, _priorTier1: TierOutput | null): Promise<TierOutput> {
+  return {
+    tier_id: 2,
+    verdict: 'uncertain',
+    confidence: 0,
+    reasoning:
+      `Tier 2 (LLM-as-Judge) is not yet implemented. ` +
+      `Claim '${claim.claim_id}' (${claim.claim_type}) requires manual review.`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Full pipeline
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the HERALD evaluation pipeline for a single claim.
+ *
+ * - If skipNLI is false: run Tier 1; escalate to Tier 2 only on 'uncertain'.
+ * - If skipNLI is true: skip directly to Tier 2.
+ *
+ * Returns a full HeraldResult suitable for agent revision feedback.
+ */
+export async function evaluateClaim(claim: NotesLogEntry): Promise<HeraldResult> {
+  const route = routeClaim(claim);
+  const tierDetails: HeraldResult['tier_details'] = {
+    tier_1: null,
+    tier_2: null,
+    tier_3: null,
+    tier_4: null,
+  };
+
+  let tier1Output: TierOutput | null = null;
+  let tier2Output: TierOutput | null = null;
+
+  // -- Tier 1 --
+  if (!route.skipNLI) {
+    tier1Output = await evaluateWithNLI(claim);
+    tierDetails.tier_1 = tier1Output;
+
+    if (tier1Output.verdict === 'valid' || tier1Output.verdict === 'invalid') {
+      // Early exit: confident verdict from Tier 1
+      return _buildResult(claim, tier1Output.verdict, tier1Output, tierDetails);
+    }
+    // 'uncertain' → fall through to Tier 2
+  }
+
+  // -- Tier 2 --
+  tier2Output = await _tier2Stub(claim, tier1Output);
+  tierDetails.tier_2 = tier2Output;
+
+  return _buildResult(claim, tier2Output.verdict, tier2Output, tierDetails);
+}
+
+// ---------------------------------------------------------------------------
+// Result builder
+// ---------------------------------------------------------------------------
+
+function _buildResult(
+  claim: NotesLogEntry,
+  verdict: HeraldResult['verdict'],
+  decidingTier: TierOutput,
+  tierDetails: HeraldResult['tier_details'],
+): HeraldResult {
+  const tierReached = decidingTier.tier_id;
+  return {
+    claim_id: claim.claim_id,
+    tier_reached: tierReached,
+    verdict,
+    confidence: decidingTier.confidence,
+    feedback: decidingTier.reasoning,
+    suggested_revision: decidingTier.suggested_revision ?? null,
+    tier_details: tierDetails,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Convenience: which claim types skip Tier 1?
+// ---------------------------------------------------------------------------
+
+export function claimTypesSkippingNLI(): ClaimType[] {
+  return (Object.entries(CLAIM_TYPE_CONFIG) as Array<[ClaimType, (typeof CLAIM_TYPE_CONFIG)[ClaimType]]>)
+    .filter(([, cfg]) => cfg.skipNLI)
+    .map(([claimType]) => claimType);
+}
+
+export function claimTypesUsingNLI(): ClaimType[] {
+  return (Object.entries(CLAIM_TYPE_CONFIG) as Array<[ClaimType, (typeof CLAIM_TYPE_CONFIG)[ClaimType]]>)
+    .filter(([, cfg]) => !cfg.skipNLI)
+    .map(([claimType]) => claimType);
+}

--- a/src/herald/tier1-nli.ts
+++ b/src/herald/tier1-nli.ts
@@ -1,0 +1,194 @@
+/**
+ * HERALD Tier 1 — NLI client.
+ *
+ * Calls the local Python NLI service (DeBERTa-v3-large-mnli running via
+ * Hugging Face Transformers or ONNX Runtime).  This is intentionally NOT
+ * an Anthropic API call — it is the cheap, local filter that prevents
+ * unnecessary LLM calls in Tiers 2–3.
+ *
+ * Routing guard: this module must NEVER be called for predictive, normative,
+ * or synthesis claims (skipNLI === true).  The router enforces this, but we
+ * also throw here to catch bugs early.
+ */
+
+import { CLAIM_TYPE_CONFIG, type NotesLogEntry } from '../types/claims';
+import type { TierOutput } from '../types/herald';
+
+// ---------------------------------------------------------------------------
+// Backend URL configuration
+// ---------------------------------------------------------------------------
+
+const API_BASE =
+  (typeof process !== 'undefined' && process.env['NEXT_PUBLIC_API_URL']) ||
+  'http://localhost:8000';
+
+// ---------------------------------------------------------------------------
+// Types mirroring the Python NLI response schema
+// ---------------------------------------------------------------------------
+
+interface NLIScores {
+  entailment: number;
+  neutral: number;
+  contradiction: number;
+}
+
+interface NLIResponseItem {
+  label: string;
+  scores: NLIScores;
+}
+
+interface NLIBatchResponse {
+  results: NLIResponseItem[];
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation logic
+// ---------------------------------------------------------------------------
+
+type AggregatedLabel = 'entailment' | 'neutral' | 'contradiction';
+
+interface AggregatedResult {
+  label: AggregatedLabel;
+  /** Confidence of the winning label, averaged across sources. */
+  confidence: number;
+  /** Raw scores per source, for reasoning. */
+  perSourceScores: NLIScores[];
+}
+
+/**
+ * Aggregate NLI results across multiple sources for a single claim.
+ *
+ * Rules (in priority order):
+ * 1. Any source returns contradiction → aggregate = contradiction
+ *    (confidence = max contradiction score across all sources)
+ * 2. All sources return entailment → aggregate = entailment
+ *    (confidence = min entailment score — weakest link)
+ * 3. Mixed → aggregate = neutral
+ *    (confidence = average neutral score)
+ */
+function aggregateResults(items: NLIResponseItem[]): AggregatedResult {
+  const perSourceScores = items.map((i) => i.scores);
+
+  const contradictionScores = items
+    .filter((i) => i.label === 'contradiction')
+    .map((i) => i.scores.contradiction);
+
+  if (contradictionScores.length > 0) {
+    const maxContradiction = Math.max(...contradictionScores);
+    return { label: 'contradiction', confidence: maxContradiction, perSourceScores };
+  }
+
+  const allEntail = items.every((i) => i.label === 'entailment');
+  if (allEntail) {
+    // Use the minimum entailment score (weakest-link aggregation)
+    const minEntailment = Math.min(...items.map((i) => i.scores.entailment));
+    return { label: 'entailment', confidence: minEntailment, perSourceScores };
+  }
+
+  // Mixed signals → neutral
+  const avgNeutral =
+    perSourceScores.reduce((sum, s) => sum + s.neutral, 0) / perSourceScores.length;
+  return { label: 'neutral', confidence: avgNeutral, perSourceScores };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP call
+// ---------------------------------------------------------------------------
+
+async function callNLIBatch(pairs: Array<{ premise: string; hypothesis: string }>): Promise<NLIBatchResponse> {
+  const url = `${API_BASE}/api/herald/nli/batch`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ pairs }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`NLI service error ${response.status}: ${body}`);
+  }
+
+  return response.json() as Promise<NLIBatchResponse>;
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate a claim at HERALD Tier 1 using the local NLI model.
+ *
+ * @throws {Error} if the claim type has skipNLI === true
+ *   (router should prevent this, but we guard defensively)
+ */
+export async function evaluateWithNLI(claim: NotesLogEntry): Promise<TierOutput> {
+  const config = CLAIM_TYPE_CONFIG[claim.claim_type];
+
+  // Guard: Tier 1 is invalid for predictive / normative / synthesis claims
+  if (config.skipNLI) {
+    throw new Error(
+      `evaluateWithNLI() called for claim type '${claim.claim_type}' which has skipNLI=true. ` +
+        `The router must direct this claim type to Tier 2.`,
+    );
+  }
+
+  const threshold = config.nliEscalationThreshold ?? 0.9;
+
+  // Build premise–hypothesis pairs: one per source chunk
+  const pairs = claim.sources.map((src) => ({
+    premise: src.relevant_chunk,
+    hypothesis: claim.claim_text,
+  }));
+
+  const batchResponse = await callNLIBatch(pairs);
+  const agg = aggregateResults(batchResponse.results);
+
+  // ---------------------------------------------------------------------------
+  // Decision logic
+  // ---------------------------------------------------------------------------
+
+  if (agg.label === 'entailment' && agg.confidence >= threshold) {
+    return {
+      tier_id: 1,
+      verdict: 'valid',
+      confidence: agg.confidence,
+      reasoning:
+        `All ${pairs.length} source(s) entail the claim with confidence ` +
+        `${(agg.confidence * 100).toFixed(1)}% (threshold: ${(threshold * 100).toFixed(0)}%).`,
+    };
+  }
+
+  if (agg.label === 'contradiction' && agg.confidence > 0.7) {
+    const contradictingCount = batchResponse.results.filter(
+      (r) => r.label === 'contradiction',
+    ).length;
+    return {
+      tier_id: 1,
+      verdict: 'invalid',
+      confidence: agg.confidence,
+      reasoning:
+        `NLI detected a contradiction between the claim and ` +
+        `${contradictingCount} of ${pairs.length} source chunk(s). ` +
+        `Contradiction confidence: ${(agg.confidence * 100).toFixed(1)}%.`,
+      suggested_revision:
+        'Verify the claim against the cited source. The claim may misrepresent the direction ' +
+        'or magnitude of the finding. Consider quoting directly or paraphrasing more carefully.',
+    };
+  }
+
+  // Neutral, mixed signals, or confidence below threshold → escalate
+  const entailCount = batchResponse.results.filter((r) => r.label === 'entailment').length;
+  const neutralCount = batchResponse.results.filter((r) => r.label === 'neutral').length;
+  const contraCount = batchResponse.results.filter((r) => r.label === 'contradiction').length;
+
+  return {
+    tier_id: 1,
+    verdict: 'uncertain',
+    confidence: agg.confidence,
+    reasoning:
+      `NLI result inconclusive across ${pairs.length} source(s): ` +
+      `${entailCount} entailment, ${neutralCount} neutral, ${contraCount} contradiction. ` +
+      `Aggregate label '${agg.label}' with confidence ${(agg.confidence * 100).toFixed(1)}% ` +
+      `(threshold: ${(threshold * 100).toFixed(0)}%). Escalating to Tier 2.`,
+  };
+}

--- a/tests/herald/tier1.test.ts
+++ b/tests/herald/tier1.test.ts
@@ -1,0 +1,399 @@
+/**
+ * HERALD Tier 1 — TypeScript tests.
+ *
+ * These tests mock the fetch call to the Python NLI service so no backend
+ * is required.  They verify:
+ *
+ *  - Statistical/comparative claims are routed through Tier 1
+ *  - Causal claims use the lower 0.85 threshold
+ *  - Predictive/normative/synthesis claims skip Tier 1 entirely
+ *  - Entailment above threshold → verdict 'valid'
+ *  - Contradiction above 0.7 → verdict 'invalid' with suggested revision
+ *  - Low-confidence / neutral → verdict 'uncertain'
+ *  - The client correctly posts to /api/herald/nli/batch
+ *  - Guard throws when skipNLI claim type is passed directly to evaluateWithNLI
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ClaimType, DerivationMethod, type NotesLogEntry, type Source } from '../../src/types/claims';
+import { evaluateWithNLI } from '../../src/herald/tier1-nli';
+import {
+  claimTypesSkippingNLI,
+  claimTypesUsingNLI,
+  evaluateClaim,
+  routeClaim,
+} from '../../src/herald/router';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeSource(chunk: string, id = 'S-001'): Source {
+  return {
+    source_id: id,
+    source_title: 'Test Source',
+    source_url: 'https://example.com',
+    relevant_chunk: chunk,
+  };
+}
+
+function makeEntry(overrides: Partial<NotesLogEntry> = {}): NotesLogEntry {
+  return {
+    claim_id: 'C-001',
+    claim_text: 'The unemployment rate is 5.2%.',
+    claim_type: ClaimType.Statistical,
+    derivation: DerivationMethod.DirectExtraction,
+    sources: [makeSource('The unemployment rate is 5.2%.')],
+    reasoning: 'Direct extraction.',
+    ...overrides,
+  };
+}
+
+/** Build a mock fetch Response for the /nli/batch endpoint. */
+function mockNLIBatch(
+  labels: Array<{ label: string; entailment: number; neutral: number; contradiction: number }>,
+) {
+  const results = labels.map(({ label, entailment, neutral, contradiction }) => ({
+    label,
+    scores: { entailment, neutral, contradiction },
+  }));
+  return Promise.resolve(
+    new Response(JSON.stringify({ results }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Router: routeClaim
+// ---------------------------------------------------------------------------
+
+describe('routeClaim', () => {
+  it('routes statistical claims to Tier 1 with threshold 0.9', () => {
+    const decision = routeClaim(makeEntry({ claim_type: ClaimType.Statistical }));
+    expect(decision.startTier).toBe(1);
+    expect(decision.skipNLI).toBe(false);
+    expect(decision.nliThreshold).toBe(0.9);
+  });
+
+  it('routes comparative claims to Tier 1 with threshold 0.9', () => {
+    const decision = routeClaim(makeEntry({ claim_type: ClaimType.Comparative }));
+    expect(decision.startTier).toBe(1);
+    expect(decision.nliThreshold).toBe(0.9);
+  });
+
+  it('routes causal claims to Tier 1 with lower threshold 0.85', () => {
+    const decision = routeClaim(makeEntry({ claim_type: ClaimType.Causal }));
+    expect(decision.startTier).toBe(1);
+    expect(decision.skipNLI).toBe(false);
+    expect(decision.nliThreshold).toBe(0.85);
+  });
+
+  it('routes predictive claims to Tier 2 (skipNLI)', () => {
+    const decision = routeClaim(makeEntry({ claim_type: ClaimType.Predictive }));
+    expect(decision.startTier).toBe(2);
+    expect(decision.skipNLI).toBe(true);
+    expect(decision.nliThreshold).toBeNull();
+  });
+
+  it('routes normative claims to Tier 2 (skipNLI)', () => {
+    const decision = routeClaim(makeEntry({ claim_type: ClaimType.Normative }));
+    expect(decision.startTier).toBe(2);
+    expect(decision.skipNLI).toBe(true);
+  });
+
+  it('routes synthesis claims to Tier 2 (skipNLI)', () => {
+    const decision = routeClaim(makeEntry({ claim_type: ClaimType.Synthesis }));
+    expect(decision.startTier).toBe(2);
+    expect(decision.skipNLI).toBe(true);
+  });
+});
+
+describe('claimTypesSkippingNLI / claimTypesUsingNLI', () => {
+  it('skipNLI set contains exactly predictive, normative, synthesis', () => {
+    const skipping = claimTypesSkippingNLI();
+    expect(skipping).toHaveLength(3);
+    expect(skipping).toContain(ClaimType.Predictive);
+    expect(skipping).toContain(ClaimType.Normative);
+    expect(skipping).toContain(ClaimType.Synthesis);
+  });
+
+  it('useNLI set contains exactly statistical, comparative, causal', () => {
+    const using = claimTypesUsingNLI();
+    expect(using).toHaveLength(3);
+    expect(using).toContain(ClaimType.Statistical);
+    expect(using).toContain(ClaimType.Comparative);
+    expect(using).toContain(ClaimType.Causal);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateWithNLI: guard check
+// ---------------------------------------------------------------------------
+
+describe('evaluateWithNLI guard', () => {
+  it.each([ClaimType.Predictive, ClaimType.Normative, ClaimType.Synthesis])(
+    'throws for skipNLI claim type: %s',
+    async (claimType) => {
+      const claim = makeEntry({ claim_type: claimType });
+      await expect(evaluateWithNLI(claim)).rejects.toThrow(/skipNLI=true/);
+    },
+  );
+
+  it('does NOT throw for statistical claim', async () => {
+    fetchMock.mockReturnValueOnce(
+      mockNLIBatch([{ label: 'entailment', entailment: 0.95, neutral: 0.03, contradiction: 0.02 }]),
+    );
+    const claim = makeEntry({ claim_type: ClaimType.Statistical });
+    await expect(evaluateWithNLI(claim)).resolves.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateWithNLI: verdict logic
+// ---------------------------------------------------------------------------
+
+describe('evaluateWithNLI verdicts', () => {
+  it('returns valid when entailment confidence > 0.9 (statistical)', async () => {
+    fetchMock.mockReturnValueOnce(
+      mockNLIBatch([{ label: 'entailment', entailment: 0.95, neutral: 0.03, contradiction: 0.02 }]),
+    );
+
+    const result = await evaluateWithNLI(makeEntry({ claim_type: ClaimType.Statistical }));
+
+    expect(result.verdict).toBe('valid');
+    expect(result.confidence).toBeCloseTo(0.95);
+    expect(result.tier_id).toBe(1);
+  });
+
+  it('returns uncertain when entailment < threshold (0.9 for statistical)', async () => {
+    fetchMock.mockReturnValueOnce(
+      mockNLIBatch([{ label: 'entailment', entailment: 0.8, neutral: 0.15, contradiction: 0.05 }]),
+    );
+
+    const result = await evaluateWithNLI(makeEntry({ claim_type: ClaimType.Statistical }));
+
+    expect(result.verdict).toBe('uncertain');
+    expect(result.tier_id).toBe(1);
+  });
+
+  it('returns valid for causal claim when entailment >= 0.85 (lower threshold)', async () => {
+    fetchMock.mockReturnValueOnce(
+      mockNLIBatch([{ label: 'entailment', entailment: 0.87, neutral: 0.08, contradiction: 0.05 }]),
+    );
+
+    const result = await evaluateWithNLI(makeEntry({ claim_type: ClaimType.Causal }));
+
+    expect(result.verdict).toBe('valid');
+  });
+
+  it('returns uncertain for causal claim when entailment < 0.85', async () => {
+    fetchMock.mockReturnValueOnce(
+      mockNLIBatch([{ label: 'entailment', entailment: 0.82, neutral: 0.1, contradiction: 0.08 }]),
+    );
+
+    const result = await evaluateWithNLI(makeEntry({ claim_type: ClaimType.Causal }));
+
+    expect(result.verdict).toBe('uncertain');
+  });
+
+  it('returns invalid with suggested_revision when contradiction > 0.7', async () => {
+    fetchMock.mockReturnValueOnce(
+      mockNLIBatch([{ label: 'contradiction', entailment: 0.05, neutral: 0.1, contradiction: 0.85 }]),
+    );
+
+    const result = await evaluateWithNLI(makeEntry({ claim_type: ClaimType.Statistical }));
+
+    expect(result.verdict).toBe('invalid');
+    expect(result.suggested_revision).toBeTruthy();
+    expect(result.tier_id).toBe(1);
+  });
+
+  it('returns uncertain when contradiction is weak (< 0.7)', async () => {
+    fetchMock.mockReturnValueOnce(
+      mockNLIBatch([{ label: 'contradiction', entailment: 0.2, neutral: 0.45, contradiction: 0.35 }]),
+    );
+
+    const result = await evaluateWithNLI(makeEntry({ claim_type: ClaimType.Statistical }));
+
+    // Contradiction is the dominant label but confidence < 0.7 → uncertain
+    expect(result.verdict).toBe('uncertain');
+  });
+
+  it('returns uncertain for neutral aggregate', async () => {
+    fetchMock.mockReturnValueOnce(
+      mockNLIBatch([{ label: 'neutral', entailment: 0.2, neutral: 0.65, contradiction: 0.15 }]),
+    );
+
+    const result = await evaluateWithNLI(makeEntry({ claim_type: ClaimType.Statistical }));
+
+    expect(result.verdict).toBe('uncertain');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateWithNLI: multi-source aggregation
+// ---------------------------------------------------------------------------
+
+describe('evaluateWithNLI multi-source aggregation', () => {
+  it('all sources entail → valid (uses min entailment score)', async () => {
+    fetchMock.mockReturnValueOnce(
+      mockNLIBatch([
+        { label: 'entailment', entailment: 0.95, neutral: 0.03, contradiction: 0.02 },
+        { label: 'entailment', entailment: 0.91, neutral: 0.05, contradiction: 0.04 },
+      ]),
+    );
+
+    const claim = makeEntry({
+      claim_type: ClaimType.Statistical,
+      sources: [
+        makeSource('Chunk 1', 'S-001'),
+        makeSource('Chunk 2', 'S-002'),
+      ],
+    });
+    const result = await evaluateWithNLI(claim);
+
+    expect(result.verdict).toBe('valid');
+    // Confidence should be the min entailment (0.91)
+    expect(result.confidence).toBeCloseTo(0.91);
+  });
+
+  it('any source contradicts → contradiction wins (all-entail + one contradiction)', async () => {
+    fetchMock.mockReturnValueOnce(
+      mockNLIBatch([
+        { label: 'entailment', entailment: 0.95, neutral: 0.03, contradiction: 0.02 },
+        { label: 'contradiction', entailment: 0.05, neutral: 0.1, contradiction: 0.85 },
+      ]),
+    );
+
+    const claim = makeEntry({
+      claim_type: ClaimType.Statistical,
+      sources: [makeSource('Chunk A', 'S-001'), makeSource('Chunk B', 'S-002')],
+    });
+    const result = await evaluateWithNLI(claim);
+
+    expect(result.verdict).toBe('invalid');
+  });
+
+  it('mixed entail + neutral → uncertain', async () => {
+    fetchMock.mockReturnValueOnce(
+      mockNLIBatch([
+        { label: 'entailment', entailment: 0.92, neutral: 0.05, contradiction: 0.03 },
+        { label: 'neutral', entailment: 0.3, neutral: 0.6, contradiction: 0.1 },
+      ]),
+    );
+
+    const claim = makeEntry({
+      claim_type: ClaimType.Statistical,
+      sources: [makeSource('Chunk A', 'S-001'), makeSource('Chunk B', 'S-002')],
+    });
+    const result = await evaluateWithNLI(claim);
+
+    expect(result.verdict).toBe('uncertain');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateWithNLI: HTTP call verification
+// ---------------------------------------------------------------------------
+
+describe('evaluateWithNLI HTTP call', () => {
+  it('sends POST to /api/herald/nli/batch with correct payload', async () => {
+    fetchMock.mockReturnValueOnce(
+      mockNLIBatch([{ label: 'entailment', entailment: 0.95, neutral: 0.03, contradiction: 0.02 }]),
+    );
+
+    const claim = makeEntry({
+      sources: [makeSource('The unemployment rate is 5.2%.', 'S-001')],
+    });
+    await evaluateWithNLI(claim);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(url).toMatch(/\/api\/herald\/nli\/batch$/);
+    expect(options.method).toBe('POST');
+
+    const body = JSON.parse(options.body as string) as { pairs: Array<{ premise: string; hypothesis: string }> };
+    expect(body.pairs).toHaveLength(1);
+    expect(body.pairs[0]!.premise).toBe('The unemployment rate is 5.2%.');
+    expect(body.pairs[0]!.hypothesis).toBe(claim.claim_text);
+  });
+
+  it('throws when the NLI service returns a non-200 status', async () => {
+    fetchMock.mockReturnValueOnce(
+      Promise.resolve(
+        new Response(JSON.stringify({ detail: 'not loaded' }), {
+          status: 503,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+
+    await expect(evaluateWithNLI(makeEntry())).rejects.toThrow(/503/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateClaim: predictive/normative/synthesis skip Tier 1
+// ---------------------------------------------------------------------------
+
+describe('evaluateClaim routing', () => {
+  it.each([ClaimType.Predictive, ClaimType.Normative, ClaimType.Synthesis])(
+    'never calls fetch for skipNLI type: %s',
+    async (claimType) => {
+      const claim = makeEntry({ claim_type: claimType });
+      // evaluateClaim will hit the Tier 2 stub (no fetch needed)
+      const result = await evaluateClaim(claim);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(result.tier_details.tier_1).toBeNull();
+      expect(result.tier_details.tier_2).not.toBeNull();
+    },
+  );
+
+  it('statistical claim with entailment exits at Tier 1 without calling Tier 2', async () => {
+    fetchMock.mockReturnValueOnce(
+      mockNLIBatch([{ label: 'entailment', entailment: 0.96, neutral: 0.02, contradiction: 0.02 }]),
+    );
+
+    const claim = makeEntry({ claim_type: ClaimType.Statistical });
+    const result = await evaluateClaim(claim);
+
+    expect(result.tier_reached).toBe(1);
+    expect(result.verdict).toBe('valid');
+    expect(result.tier_details.tier_1).not.toBeNull();
+    expect(result.tier_details.tier_2).toBeNull();
+    // fetch called exactly once (the NLI batch call)
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('statistical claim with uncertain Tier 1 escalates to Tier 2', async () => {
+    fetchMock.mockReturnValueOnce(
+      mockNLIBatch([{ label: 'neutral', entailment: 0.5, neutral: 0.4, contradiction: 0.1 }]),
+    );
+
+    const claim = makeEntry({ claim_type: ClaimType.Statistical });
+    const result = await evaluateClaim(claim);
+
+    expect(result.tier_details.tier_1).not.toBeNull();
+    expect(result.tier_details.tier_2).not.toBeNull();
+    expect(result.tier_reached).toBe(2);
+  });
+});


### PR DESCRIPTION
… router

Part A (Python):
- backend/services/nli_service.py: NLIService wrapping HF Transformers pipeline (microsoft/deberta-v3-large-mnli, CPU/GPU auto-detect) with ONNX Runtime fallback when NLI_ONNX_MODEL_PATH is set; module-level singleton loaded once at FastAPI startup; _parse_hf_output exported for unit testing
- backend/api/routes/herald.py: replace 501 stub with POST /api/herald/nli (single pair) and POST /api/herald/nli/batch; FastAPI dependency_overrides- compatible via Annotated[NLIService, Depends(...)] pattern; 503 guard when model not loaded
- backend/api/app.py: wire NLI load() into lifespan handler with graceful degradation on ImportError (transformers not installed)
- backend/api/routes/health.py: /health/nli now reports real model status
- backend/tests/test_herald/test_tier1_nli.py: 15 fast unit tests (no model download); 5 @slow @tier1 tests for real DeBERTa entailment/contradiction/ neutral detection

Part B (TypeScript):
- src/herald/tier1-nli.ts: evaluateWithNLI() calls /api/herald/nli/batch, aggregates multi-source results (contradiction wins, min-entailment for all- entail, neutral for mixed), applies per-type thresholds from CLAIM_TYPE_CONFIG, throws on skipNLI claim types as a guard
- src/herald/router.ts: routeClaim() maps claim_type to start tier; evaluateClaim() runs Tier 1 with early exit on confident verdicts and falls through to Tier 2 stub on uncertain; claimTypesSkippingNLI/claimTypesUsingNLI helpers
- tests/herald/tier1.test.ts: 30 vitest tests covering routing table, guard throws, verdict thresholds (0.9 statistical/comparative, 0.85 causal), multi-source aggregation, HTTP payload verification, skipNLI routing